### PR TITLE
Remove Duplicate Prerequisites and Corequisites Fields for Vancouver Campus

### DIFF
--- a/resources/views/syllabus/syllabus.blade.php
+++ b/resources/views/syllabus/syllabus.blade.php
@@ -51,64 +51,64 @@
                     <button type="button" class="btn m-0 p-0" data-bs-toggle="tooltip"
                         data-bs-placement="bottom" title="Import an existing course" style="background:none;border:none"><i
                             class="text-secondary bi bi-box-arrow-in-down-left btn btn-light rounded-circle m-2"></i>
-                            <p style="font-size:12px" class="text-muted m-0">IMPORT</p>
-                        </button>
+                        <p style="font-size:12px" class="text-muted m-0">IMPORT</p>
+                    </button>
                 </span>
             </div>
-    
+
             @if (!empty($syllabus))
-                @include('modals.syllabusCollabsModal', ['syllabus' => $syllabus, 'user' => $user])
-                <div class="col-2" style="max-width:10%">
-                    <span data-bs-toggle="modal" data-bs-target="#addSyllabusCollaboratorsModal{{$syllabus->id}}">
-                        <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
-                            data-bs-placement="bottom" title="Add collaborators to my syllabus"><i
-                                class="text-primary bi bi-people-fill btn btn-light rounded-circle m-2"></i>
-                            <p style="font-size:12px" class="text-muted m-0">PEOPLE</p>
-                        </button>
-                    </span>
-                </div>
-        
-                @include('modals.duplicateModal', ['syllabus' => $syllabus])
-                <div class="col-2" style="max-width:10%">
-                    <span data-bs-toggle="modal" data-bs-target="#duplicateConfirmation">
-                        <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
-                            data-bs-placement="bottom" title="Make a copy of my syllabus"><i
-                                class="btn btn-light rounded-circle m-2 text-success bi bi-files"></i>
-                                <p style="font-size:12px" class="text-muted m-0">COPY</p>
-                        </button>
-                    </span>
-                </div>
-        
-                @include('modals.deleteModal', ['syllabus' => $syllabus])
-                <div class="col-2" style="max-width:10%">
-                    <span data-bs-toggle="modal" data-bs-target="#deleteSyllabusConfirmation">
-                        <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
-                            data-bs-placement="bottom" title="Delete my syllabus"><i class="btn btn-danger rounded-circle m-2 bi bi-trash-fill"></i>
-                            <p style="font-size:12px" class="text-muted m-0">DELETE</p>
-                        </button>
-                    </span>
-                </div>
+            @include('modals.syllabusCollabsModal', ['syllabus' => $syllabus, 'user' => $user])
+            <div class="col-2" style="max-width:10%">
+                <span data-bs-toggle="modal" data-bs-target="#addSyllabusCollaboratorsModal{{$syllabus->id}}">
+                    <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
+                        data-bs-placement="bottom" title="Add collaborators to my syllabus"><i
+                            class="text-primary bi bi-people-fill btn btn-light rounded-circle m-2"></i>
+                        <p style="font-size:12px" class="text-muted m-0">PEOPLE</p>
+                    </button>
+                </span>
+            </div>
+
+            @include('modals.duplicateModal', ['syllabus' => $syllabus])
+            <div class="col-2" style="max-width:10%">
+                <span data-bs-toggle="modal" data-bs-target="#duplicateConfirmation">
+                    <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
+                        data-bs-placement="bottom" title="Make a copy of my syllabus"><i
+                            class="btn btn-light rounded-circle m-2 text-success bi bi-files"></i>
+                        <p style="font-size:12px" class="text-muted m-0">COPY</p>
+                    </button>
+                </span>
+            </div>
+
+            @include('modals.deleteModal', ['syllabus' => $syllabus])
+            <div class="col-2" style="max-width:10%">
+                <span data-bs-toggle="modal" data-bs-target="#deleteSyllabusConfirmation">
+                    <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
+                        data-bs-placement="bottom" title="Delete my syllabus"><i class="btn btn-danger rounded-circle m-2 bi bi-trash-fill"></i>
+                        <p style="font-size:12px" class="text-muted m-0">DELETE</p>
+                    </button>
+                </span>
+            </div>
             @endif
         </div>
     </div>
-    
-    
-    
+
+
+
     <div class="alert alert-primary d-flex align-items-center" role="alert" style="text-align:justify">
-        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>                        
+        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>
         <div>
-            To assist faculty and instructors in preparing their syllabi, this generator follows the policies and templates provided by the <a target="_blank" rel="noopener noreferrer" href="https://senate.ubc.ca/okanagan/policies/policy-o-130-content-and-distribution-of-course-syllabi-2/">UBC Okanagan</a> and <a target="_blank" rel="noopener noreferrer" href="https://senate.ubc.ca/policies-resources-support-student-success">UBC Vancouver</a> Senates. 
+            To assist faculty and instructors in preparing their syllabi, this generator follows the policies and templates provided by the <a target="_blank" rel="noopener noreferrer" href="https://senate.ubc.ca/okanagan/policies/policy-o-130-content-and-distribution-of-course-syllabi-2/">UBC Okanagan</a> and <a target="_blank" rel="noopener noreferrer" href="https://senate.ubc.ca/policies-resources-support-student-success">UBC Vancouver</a> Senates.
         </div>
     </div>
 
     @if(empty($syllabus))
-        <div class="alert alert-warning">
-            <!-- <i class="bi bi-info-circle-fill pr-2 fs-3"></i> -->
-            <button type="button" class="close" data-dismiss="alert">×</button>  
-            <div>
-                {!! $inputFieldDescriptions['saveWarning']!!}
-            </div>  
+    <div class="alert alert-warning">
+        <!-- <i class="bi bi-info-circle-fill pr-2 fs-3"></i> -->
+        <button type="button" class="close" data-dismiss="alert">×</button>
+        <div>
+            {!! $inputFieldDescriptions['saveWarning']!!}
         </div>
+    </div>
     @endif
 
 
@@ -119,7 +119,7 @@
 
         <div class="col-6">
             <label for="courseTitle" class="form-label">Course Title<span class="requiredField"> *</span><span class="requiredBySenateOK"></span></label>
-            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="100" spellcheck="true" id = "courseTitle" name = "courseTitle" class ="form-control" type="text" placeholder="E.g. Intro to Software development" required value="{{ !empty($syllabus) ? $syllabus->course_title : '' }}">
+            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="100" spellcheck="true" id="courseTitle" name="courseTitle" class="form-control" type="text" placeholder="E.g. Intro to Software development" required value="{{ !empty($syllabus) ? $syllabus->course_title : '' }}">
             <div class="invalid-tooltip">
                 Please enter the course title.
             </div>
@@ -127,23 +127,23 @@
 
         <div class="col-3">
             <label for="courseCode">Course Code<span class="requiredField"> *</span></label>
-            <input id = "courseCode" pattern="[A-Za-z]+" minlength="1" name = "courseCode" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="4" class ="form-control" type="text" placeholder="E.g. CPSC" required value="{{ !empty($syllabus) ? $syllabus->course_code : '' }}">
+            <input id="courseCode" pattern="[A-Za-z]+" minlength="1" name="courseCode" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="4" class="form-control" type="text" placeholder="E.g. CPSC" required value="{{ !empty($syllabus) ? $syllabus->course_code : '' }}">
             <div class="invalid-tooltip">
                 Please enter the course code.
             </div>
         </div>
-        
+
         <div class="col-3">
             <label for="courseNumber">Course Number<span class="requiredField"> *</span></label>
-            <input id = "courseNumber" name = "courseNumber" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="3" class ="form-control" type="number" placeholder="E.g. 310" value="{{ !empty($syllabus) ? $syllabus->course_num : '' }}">
+            <input id="courseNumber" name="courseNumber" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="3" class="form-control" type="number" placeholder="E.g. 310" value="{{ !empty($syllabus) ? $syllabus->course_num : '' }}">
             <div class="invalid-tooltip">
                 Please enter the course number.
             </div>
         </div>
 
-        
-        
-               <!--
+
+
+        <!--
              <input class="form-check-input " id="crossListed" type="checkbox" name="crossListed" value="1" checked>
                     <div id="crossListedCode" class="col-3">
                         <label for="courseCodeCL">Cross-Listed Course Code<span class="requiredField"></span></label>
@@ -160,57 +160,57 @@
                         </div>
                     </div>
             -->
-        
-            
-                @if(!empty($syllabus))
-                    @if($syllabus->cross_listed_code && $syllabus->cross_listed_num)
-                <div class="col-6">
-                    <div class="col-12">
-                        <input class="form-check-input " id="crossListed" type="checkbox" name="crossListed" value="1" checked>
-                        <label class="form-check-label mb-2" for="crossListed">{!! $inputFieldDescriptions['crossListed'] !!}</label>
-                    </div>
-                </div>
-                    <div id="crossListedCode" class="col-3">
-                        <label for="courseCodeCL">Cross-Listed Course Code<span class="requiredField"></span></label>
-                        <input id = "courseCodeCL" pattern="[A-Za-z]+" minlength="1" name = "courseCodeCL" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="4" class ="form-control" type="text" placeholder="E.g. CPSC" required value="{{ !empty($syllabus) ? $syllabus->cross_listed_code : '' }}">
-                        <div class="invalid-tooltip">
-                            Please enter the course code.
-                        </div>
-                    </div>
-                    <div id="crossListedNumber" class="col-3">
-                        <label for="courseNumberCL">Cross-Listed Course Number<span class="requiredField"></span></label>
-                        <input id = "courseNumberCL" name = "courseNumberCL" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="3" class ="form-control" type="number" placeholder="E.g. 310" value="{{ !empty($syllabus) ? $syllabus->cross_listed_num : '' }}">
-                        <div class="invalid-tooltip">
-                            Please enter the course number.
-                        </div>
-                    </div>
-                    @else
-                <div class="col-6">
-                    <div class="col-12">
-                        <input class="form-check-input " id="crossListed" type="checkbox" name="crossListed" value="1">
-                        <label class="form-check-label mb-2" for="crossListed">{!! $inputFieldDescriptions['crossListed'] !!}</label>
-                    </div>
-                </div>
-                <div id="crossListedCode" class="col-3"></div>
-                <div id="crossListedNumber" class="col-3"></div>
-                    @endif 
-                @else
-                <div class="col-6">
-                    <div class="col-12">
-                    <input class="form-check-input " id="crossListed" type="checkbox" name="crossListed" value="1">
-                    <label class="form-check-label mb-2" for="crossListed">{!! $inputFieldDescriptions['crossListed'] !!}</label> 
-                    </div>
-                </div>
-                <div id="crossListedCode" class="col-3"></div>
-            <div id="crossListedNumber" class="col-3"></div>
-                @endif
-    
-        
-        
-        
 
 
-        
+        @if(!empty($syllabus))
+        @if($syllabus->cross_listed_code && $syllabus->cross_listed_num)
+        <div class="col-6">
+            <div class="col-12">
+                <input class="form-check-input " id="crossListed" type="checkbox" name="crossListed" value="1" checked>
+                <label class="form-check-label mb-2" for="crossListed">{!! $inputFieldDescriptions['crossListed'] !!}</label>
+            </div>
+        </div>
+        <div id="crossListedCode" class="col-3">
+            <label for="courseCodeCL">Cross-Listed Course Code<span class="requiredField"></span></label>
+            <input id="courseCodeCL" pattern="[A-Za-z]+" minlength="1" name="courseCodeCL" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="4" class="form-control" type="text" placeholder="E.g. CPSC" required value="{{ !empty($syllabus) ? $syllabus->cross_listed_code : '' }}">
+            <div class="invalid-tooltip">
+                Please enter the course code.
+            </div>
+        </div>
+        <div id="crossListedNumber" class="col-3">
+            <label for="courseNumberCL">Cross-Listed Course Number<span class="requiredField"></span></label>
+            <input id="courseNumberCL" name="courseNumberCL" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="3" class="form-control" type="number" placeholder="E.g. 310" value="{{ !empty($syllabus) ? $syllabus->cross_listed_num : '' }}">
+            <div class="invalid-tooltip">
+                Please enter the course number.
+            </div>
+        </div>
+        @else
+        <div class="col-6">
+            <div class="col-12">
+                <input class="form-check-input " id="crossListed" type="checkbox" name="crossListed" value="1">
+                <label class="form-check-label mb-2" for="crossListed">{!! $inputFieldDescriptions['crossListed'] !!}</label>
+            </div>
+        </div>
+        <div id="crossListedCode" class="col-3"></div>
+        <div id="crossListedNumber" class="col-3"></div>
+        @endif
+        @else
+        <div class="col-6">
+            <div class="col-12">
+                <input class="form-check-input " id="crossListed" type="checkbox" name="crossListed" value="1">
+                <label class="form-check-label mb-2" for="crossListed">{!! $inputFieldDescriptions['crossListed'] !!}</label>
+            </div>
+        </div>
+        <div id="crossListedCode" class="col-3"></div>
+        <div id="crossListedNumber" class="col-3"></div>
+        @endif
+
+
+
+
+
+
+
 
 
         <div class="col-3">
@@ -221,7 +221,7 @@
                 <option value="V">UBC Vancouver</option>
             </select>
         </div>
-        
+
         <div class="col-3">
             <label for="faculty" class="form-label">Faculty</label>
             <select class="form-select" id="faculty" name="faculty" form="sylabusGenerator" disabled onchange="setDepartments(this.selectedOptions[0].getAttribute('name'))">
@@ -240,28 +240,28 @@
 
         <div class="col-3">
             <label for="startTime">Class Start Time</label>
-            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="20" id = "startTime" name = "startTime" class ="form-control" type="text" placeholder="E.g. 1:00 PM" value="{{ !empty($syllabus) ? $syllabus->class_start_time : ''}}">
+            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="20" id="startTime" name="startTime" class="form-control" type="text" placeholder="E.g. 1:00 PM" value="{{ !empty($syllabus) ? $syllabus->class_start_time : ''}}">
         </div>
-        
+
         <div class="col-3">
             <label for="endTime">Class End Time</label>
-            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="20" id = "endTime" name = "endTime" class ="form-control" type="text" placeholder="E.g. 2:00 PM" value="{{ !empty($syllabus) ? $syllabus->class_end_time : ''}}" >
+            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="20" id="endTime" name="endTime" class="form-control" type="text" placeholder="E.g. 2:00 PM" value="{{ !empty($syllabus) ? $syllabus->class_end_time : ''}}">
         </div>
 
         <div class="col-3">
             <label for="courseLocation">Course Location</label>
-            <input id = "courseLocation" name = "courseLocation" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="150" class ="form-control" type="text" placeholder="E.g. WEL 140" value="{{ !empty($syllabus) ? $syllabus->course_location : ''}}">
+            <input id="courseLocation" name="courseLocation" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="150" class="form-control" type="text" placeholder="E.g. WEL 140" value="{{ !empty($syllabus) ? $syllabus->course_location : ''}}">
         </div>
-        
+
         <div id="officeLocation" class="col-3"></div>
 
-                <!-- Okanagan Course Section -->
-                <div class="col-3"id="courseSectionOK"></div>
-                
+        <!-- Okanagan Course Section -->
+        <div class="col-3" id="courseSectionOK"></div>
+
         <div class="col-3">
             <label for="courseYear">Course Year <span class="requiredField">*</span></label>
             <select id="courseYear" class="form-select" name="courseYear" required>
-                <option disabled selected value="">  -- Year -- </option>
+                <option disabled selected value=""> -- Year -- </option>
                 <option value="2021" {{!empty($syllabus) ? (($syllabus->course_year == '2021') ? 'selected=true' : '') : ''}}>2021</option>
                 <option value="2022" {{!empty($syllabus) ? (($syllabus->course_year == '2022') ? 'selected=true' : '') : ''}}>2022</option>
                 <option value="2023" {{!empty($syllabus) ? (($syllabus->course_year == '2023') ? 'selected=true' : '') : ''}}>2023</option>
@@ -293,13 +293,13 @@
             </div>
         </div>
 
-        
+
         <div id="courseSemesterOther" class="col-3">
             @if (!empty($syllabus))
-                @if ($syllabus->course_term != 'W1' && $syllabus->course_term != 'W2' && $syllabus->course_term != 'S1' && $syllabus->course_term != 'S2')
-                    <label class="form-label" for="courseSemesterOther">Other</label>
-                    <input name="courseSemesterOther" type="text" class="form-control" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="49" value="{{$syllabus->course_term}}">
-                @endif
+            @if ($syllabus->course_term != 'W1' && $syllabus->course_term != 'W2' && $syllabus->course_term != 'S1' && $syllabus->course_term != 'S2')
+            <label class="form-label" for="courseSemesterOther">Other</label>
+            <input name="courseSemesterOther" type="text" class="form-control" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="49" value="{{$syllabus->course_term}}">
+            @endif
             @endif
         </div>
 
@@ -322,9 +322,9 @@
             <div class="classDate mt-1">
                 <div class="form-check form-check-inline">
                     <input id="monday" type="checkbox" name="schedule[]" value="Mon" class="form-check-input">
-                    <label for="monday" class="mr-2 form-check-label" >Monday</label>
+                    <label for="monday" class="mr-2 form-check-label">Monday</label>
                 </div>
-                
+
                 <div class="form-check form-check-inline">
                     <input id="tuesday" type="checkbox" name="schedule[]" value="Tue" class="form-check-input">
                     <label for="tuesday" class="mr-2 form-check-label">Tuesday</label>
@@ -336,7 +336,7 @@
                 </div>
 
                 <div class="form-check form-check-inline">
-                    <input id="thursday" type="checkbox" name="schedule[]" value= "Thu" class="form-check-input">
+                    <input id="thursday" type="checkbox" name="schedule[]" value="Thu" class="form-check-input">
                     <label for="thursday" class="mr-2 form-check-label">Thursday</label>
                 </div>
 
@@ -344,7 +344,7 @@
                     <input id="friday" type="checkbox" name="schedule[]" value="Fri" class="form-check-input">
                     <label for="friday" class="mr-2 form-check-label">Friday</label>
                 </div>
-                
+
                 <div class="form-check form-check-inline">
                     <input id="saturday" type="checkbox" name="schedule[]" value="Sat" class="form-check-input">
                     <label for="saturday" class="mr-2 form-check-label">Saturday</label>
@@ -354,42 +354,47 @@
 
         <div class="col-6">
             <label for="endTime">Prerequisites</label><span class="requiredBySenateOK"></span>
-            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="100" spellcheck="true" id = "prerequisites" name = "prerequisites" class ="form-control" type="text" value="{{ !empty($syllabus) ? $syllabus->prerequisites : ''}}" >
+            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="100" spellcheck="true" id="prerequisites" name="prerequisites" class="form-control" type="text" value="{{ !empty($syllabus) ? $syllabus->prerequisites : ''}}">
         </div>
         <div class="col-6">
             <label for="endTime">Corequisites</label><span class="requiredBySenateOK"></span>
-            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="100" spellcheck="true" id = "corequisites" name = "corequisites" class ="form-control" type="text" value="{{ !empty($syllabus) ? $syllabus->corequisites : ''}}" >
+            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="100" spellcheck="true" id="corequisites" name="corequisites" class="form-control" type="text" value="{{ !empty($syllabus) ? $syllabus->corequisites : ''}}">
         </div>
-        
+
         <!-- Land Acknowledgement Statement -->
         <div class="col-12" id="landAcknowledgement"></div>
-        
+
         <div class="col-12">
-            <label for="officeHour"> <h5 class="fw-bold">Office Hours</h5></label><span class="requiredBySenateOK"></span>
+            <label for="officeHour">
+                <h5 class="fw-bold">Office Hours</h5>
+            </label><span class="requiredBySenateOK"></span>
             <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['officeHours']}}"></i>
-            <textarea oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="2500" spellcheck="true" id = "officeHour" name = "officeHour" class ="form-control" type="date" form="sylabusGenerator">{{ !empty($syllabus) ? $syllabus->office_hours : ''}}</textarea>
+            <textarea oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="2500" spellcheck="true" id="officeHour" name="officeHour" class="form-control" type="date" form="sylabusGenerator">{{ !empty($syllabus) ? $syllabus->office_hours : ''}}</textarea>
         </div>
         <!-- Course Description Vancouver -->
-        <div class="col-12"id="courseDescription"></div>
+        <div class="col-12" id="courseDescription"></div>
         <!-- Course Prerequisites -->
         <div class="col-12" id="coursePrereqs"></div>
         <!-- Course Corequisites -->
         <div class="col-12" id="courseCoreqs"></div>
-        <div class="col-3"><label for="courseInstructors"><h5 class="fw-bold">Course Instructor(s)</h5></label></div><div class="col-9"><span class="requiredBySenateOK"></span></div>
-@if (!empty($syllabus) && $syllabusInstructors->count() > 0)
-    @foreach ($syllabusInstructors as $syllabusInstructor)
+        <div class="col-3"><label for="courseInstructors">
+                <h5 class="fw-bold">Course Instructor(s)</h5>
+            </label></div>
+        <div class="col-9"><span class="requiredBySenateOK"></span></div>
+        @if (!empty($syllabus) && $syllabusInstructors->count() > 0)
+        @foreach ($syllabusInstructors as $syllabusInstructor)
         <div class="instructor row g-3 align-items-end m-0 p-0">
             <div class="col-5">
                 <label for="courseInstructor">Name<span class="requiredField"> *</span></label>
-                <input name = "courseInstructor[]" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="75" class ="form-control" type="text" placeholder="E.g. Dr. J. Doe" required value="{{$syllabusInstructor->name}}">
+                <input name="courseInstructor[]" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="75" class="form-control" type="text" placeholder="E.g. Dr. J. Doe" required value="{{$syllabusInstructor->name}}">
                 <div class="invalid-tooltip">
-                Please enter the course instructor.
+                    Please enter the course instructor.
                 </div>
             </div>
 
             <div class="col-5">
                 <label for="courseInstructorEmail">Email<span class="requiredField"> *</span></label>
-                <input name = "courseInstructorEmail[]" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="75" class ="form-control" type="email" placeholder="E.g. jane.doe@ubc.ca" value="{{$syllabusInstructor->email}}" required>
+                <input name="courseInstructorEmail[]" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="75" class="form-control" type="email" placeholder="E.g. jane.doe@ubc.ca" value="{{$syllabusInstructor->email}}" required>
                 <div class="invalid-tooltip">
                     Please enter the instructors email.
                 </div>
@@ -399,32 +404,32 @@
                 <button type="button" class="btn btn-danger col" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Delete instructor" onclick="delInstructor(this)"><i class="bi bi-trash-fill"></i> Delete</button>
             </div>
         </div>
-    @endforeach 
-@else 
-    <div class="instructor row g-3 align-items-end m-0 p-0">
-        <div class="col-5">
-            <label for="courseInstructor">Name<span class="requiredField"> *</span></label>
-            <input name = "courseInstructor[]" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="75" class ="form-control" type="text" placeholder="E.g. Dr. J. Doe" required >
-            <div class="invalid-tooltip">
-            Please enter the course instructor.
+        @endforeach
+        @else
+        <div class="instructor row g-3 align-items-end m-0 p-0">
+            <div class="col-5">
+                <label for="courseInstructor">Name<span class="requiredField"> *</span></label>
+                <input name="courseInstructor[]" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="75" class="form-control" type="text" placeholder="E.g. Dr. J. Doe" required>
+                <div class="invalid-tooltip">
+                    Please enter the course instructor.
+                </div>
+            </div>
+
+            <div class="col-5">
+                <label for="courseInstructorEmail">Email<span class="requiredField"> *</span></label>
+                <input name="courseInstructorEmail[]" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="75" class="form-control" type="email" placeholder="E.g. jane.doe@ubc.ca" required>
+                <div class="invalid-tooltip">
+                    Please enter the instructors email.
+                </div>
+            </div>
+
+            <div class="col-2">
+                <button type="button" class="btn btn-danger col" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Delete instructor" onclick="delInstructor(this)">Delete</button>
             </div>
         </div>
+        @endif
 
-        <div class="col-5">
-            <label for="courseInstructorEmail">Email<span class="requiredField"> *</span></label>
-            <input name = "courseInstructorEmail[]" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="75" class ="form-control" type="email" placeholder="E.g. jane.doe@ubc.ca" required>
-            <div class="invalid-tooltip">
-                Please enter the instructors email.
-            </div>
-        </div>
-
-        <div class="col-2">
-            <button type="button" class="btn btn-danger col" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Delete instructor" onclick="delInstructor(this)">Delete</button>
-        </div>
-    </div>
-@endif
-
-<a id="addInstructorBtn" class="link-primary col-2" onclick="addInstructor()" style="cursor:pointer"><i class="bi bi-plus"></i> Add instructor</a>
+        <a id="addInstructorBtn" class="link-primary col-2" onclick="addInstructor()" style="cursor:pointer"><i class="bi bi-plus"></i> Add instructor</a>
 
         <!-- Course Contacts -->
         <div id="courseContacts" class="col-12"></div>
@@ -432,7 +437,9 @@
         <div class="col-12" id="courseInstructorBio"></div>
 
         <div class="col-12">
-            <label for="otherCourseStaff"><h5 class="fw-bold">Other Instructional Staff</h5></label>
+            <label for="otherCourseStaff">
+                <h5 class="fw-bold">Other Instructional Staff</h5>
+            </label>
             <span class="requiredBySenate"></span>
             <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['otherCourseStaff']}}"></i>
             <div id="formatStaff" class="collapsibleNotes btn-primary rounded-3"
@@ -449,18 +456,18 @@
         </div>
 
         <div class="alert alert-info">
-        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>  
+            <i class="bi bi-info-circle-fill pr-2 fs-3"></i>
             <button type="button" class="close" data-dismiss="alert">×</button>
-                <a target="_blank" rel="noopener noreferrer" href="https://ctlt-inclusiveteaching.sites.olt.ubc.ca/files/2019/08/inclusive-syllabus-digital.pdf">Guidelines to write an inclusive syllabus</a>.
+            <a target="_blank" rel="noopener noreferrer" href="https://ctlt-inclusiveteaching.sites.olt.ubc.ca/files/2019/08/inclusive-syllabus-digital.pdf">Guidelines to write an inclusive syllabus</a>.
         </div>
 
         <!-- Okanaga Course Description -->
-        <div class="col-12"id="courseDesc"></div>
+        <div class="col-12" id="courseDesc"></div>
         <!-- Course Format -->
         <div class="col-12" id="courseFormat"></div>
         <!-- Course Overview -->
         <div class="col-12" id="courseOverview"></div>
-        
+
         <!-- Course Structure -->
         <div class="col-12" id="courseStructure"></div>
 
@@ -469,7 +476,10 @@
             <label for="courseSchedule">
                 <table>
                     <tr>
-                        <td><div><h5 class="fw-bold">Schedule of Topics and Assessments</h5></td>
+                        <td>
+                            <div>
+                                <h5 class="fw-bold">Schedule of Topics and Assessments</h5>
+                        </td>
                         <td><span class="requiredBySenateOK"></span></td>
                         <td><i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['courseSchedule']}}"></i></td>
                     </tr>
@@ -486,7 +496,7 @@
         </div>
 
         <!-- course schedule toolbar -->
-        <div id="courseScheduleTblToolbar" class="row mb-1" @if (!empty($syllabus)) @if ($courseScheduleTblRowsCount <= 0) hidden @endif @else hidden @endif>
+        <div id="courseScheduleTblToolbar" class="row mb-1" @if (!empty($syllabus)) @if ($courseScheduleTblRowsCount <=0) hidden @endif @else hidden @endif>
             <div class="col-12 text-center">
                 <span title="Row Limit Reached!" data-bs-trigger="manual" data-bs-toggle="popover"
                     data-bs-placement="bottom" data-bs-content="You have reached the maximum number of rows allowed">
@@ -502,7 +512,7 @@
                             <span class="iconify-inline ml-1" data-icon="clarity:view-columns-line" data-rotate="90deg"></span>
                         </i>
                         <p style="font-size:12px" class="text-muted m-0">ADD ROW BOTTOM</p>
-                    </button>                    
+                    </button>
                 </span>
 
                 <span title="Column Limit Reached!" data-bs-trigger="manual" data-bs-toggle="popover"
@@ -512,14 +522,14 @@
                             <span class="iconify-inline ml-1" data-icon="clarity:view-columns-line" data-rotate="180deg"></span>
                         </i>
                         <p style="font-size:12px" class="text-muted m-0">ADD COLUMN LEFT</p>
-                    </button>  
+                    </button>
 
                     <button type="button" class="col-2 addCol btn m-0 p-0" style="background:none;border:none" data-side="right" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Add column on left">
                         <i class="btn btn-light rounded-pill m-2 text-secondary bi bi-plus">
                             <span class="iconify-inline ml-1" data-icon="clarity:view-columns-line"></span>
                         </i>
                         <p style="font-size:12px" class="text-muted m-0">ADD COLUMN RIGHT</p>
-                    </button>  
+                    </button>
                 </span>
 
                 <button id="delCols" type="button" class="col-2 btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Delete column(s)">
@@ -529,14 +539,14 @@
                     <p style="font-size:12px" class="text-muted m-0">DELETE COLUMN(S)</p>
                 </button>
 
-                
+
                 <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="Delete Table" class="col-2">
                     <button id="delTable" type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="modal" data-bs-target="#delCourseScheduleTbl">
                         <i class="btn btn-danger rounded-pill m-2 bi bi-trash-fill">
                             <span class="iconify-inline" data-icon="fluent:table-48-filled"></span>
                         </i>
                         <p style="font-size:12px" class="text-muted m-0">DELETE TABLE</p>
-                    </button>                    
+                    </button>
                 </span>
             </div>
         </div>
@@ -544,616 +554,636 @@
         <!-- div where course schedule table is created from scratch  -->
         <div id="courseScheduleTblDiv">
             @if (!empty($syllabus))
-                @if ($courseScheduleTblRowsCount > 0)
-                    <table id="courseScheduleTbl" class="table table-light align-middle reorder-tbl-rows">
-                        <thead>
-                            <tr class="table-primary">
-                                <th></th>
-                                @foreach ($myCourseScheduleTbl['rows'][0] as $headerIndex => $header)
-                                <th>
-                                    <textarea name="courseScheduleTblHeadings[]" form="sylabusGenerator" type="text"
-                                        class="form-control" spellcheck="true"
-                                        placeholder="Column heading here ...">{{$header->val}}</textarea>
-                                </th>
-                                @endforeach
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach ($myCourseScheduleTbl['rows'] as $rowIndex => $row)
-                            @if ($rowIndex != 0)
-                            <tr>
-                                <td class="align-middle fs-5">↕</td>
-                                @foreach ($row as $colIndex => $data)
-                                <td>
-                                    <textarea name="courseScheduleTblRows[]" form="sylabusGenerator" type="text"
-                                        class="form-control" spellcheck="true"
-                                        placeholder="Data here ...">{{$data->val}}</textarea>
-                                </td>
-                                @endforeach
-                                <td class="align-middle">
-                                    <i class="bi bi-x-circle-fill text-danger fs-4 btn"
-                                        onclick="delCourseScheduleRow(this)"></i>
-                                </td>
-                            </tr>
-                            @endif
-                            @endforeach
-                        </tbody>
-                    </table>
-                @endif
+            @if ($courseScheduleTblRowsCount > 0)
+            <table id="courseScheduleTbl" class="table table-light align-middle reorder-tbl-rows">
+                <thead>
+                    <tr class="table-primary">
+                        <th></th>
+                        @foreach ($myCourseScheduleTbl['rows'][0] as $headerIndex => $header)
+                        <th>
+                            <textarea name="courseScheduleTblHeadings[]" form="sylabusGenerator" type="text"
+                                class="form-control" spellcheck="true"
+                                placeholder="Column heading here ...">{{$header->val}}</textarea>
+                        </th>
+                        @endforeach
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($myCourseScheduleTbl['rows'] as $rowIndex => $row)
+                    @if ($rowIndex != 0)
+                    <tr>
+                        <td class="align-middle fs-5">↕</td>
+                        @foreach ($row as $colIndex => $data)
+                        <td>
+                            <textarea name="courseScheduleTblRows[]" form="sylabusGenerator" type="text"
+                                class="form-control" spellcheck="true"
+                                placeholder="Data here ...">{{$data->val}}</textarea>
+                        </td>
+                        @endforeach
+                        <td class="align-middle">
+                            <i class="bi bi-x-circle-fill text-danger fs-4 btn"
+                                onclick="delCourseScheduleRow(this)"></i>
+                        </td>
+                    </tr>
+                    @endif
+                    @endforeach
+                </tbody>
+            </table>
+            @endif
             @endif
         </div>
 
         <div class="col-12">
-            <label for="learningOutcome"><h5 class="fw-bold">Learning Outcomes or Objectives</h5></label><span class="requiredBySenateOK"></span>
+            <label for="learningOutcome">
+                <h5 class="fw-bold">Learning Outcomes or Objectives</h5>
+            </label><span class="requiredBySenateOK"></span>
             <span class="requiredBySenate"></span>
             <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['learningOutcomes']}}"></i>
             <p class="inputFieldDescription"><i>Upon successful completion of this course, students will be able to ...</i></p>
             <div id="formatCLOs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>                                        
-            </div>                                            
-            <textarea oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="17500" id = "learningOutcome" data-formatnoteid="formatCLOs" placeholder="E.g. Define ... &#10;E.g. Classify ..." name = "learningOutcome" class ="form-control" type="date" style="height:125px;" form="sylabusGenerator" spellcheck="true">{{ !empty($syllabus) ? $syllabus->learning_outcomes : ''}}</textarea>
+                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+            </div>
+            <textarea oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="17500" id="learningOutcome" data-formatnoteid="formatCLOs" placeholder="E.g. Define ... &#10;E.g. Classify ..." name="learningOutcome" class="form-control" type="date" style="height:125px;" form="sylabusGenerator" spellcheck="true">{{ !empty($syllabus) ? $syllabus->learning_outcomes : ''}}</textarea>
         </div>
-        
+
         <div class="col-12">
-            <label for="learningActivities"><h5 class="fw-bold">Learning Activities</h5></label><span class="requiredBySenateOK"></span>
+            <label for="learningActivities">
+                <h5 class="fw-bold">Learning Activities</h5>
+            </label><span class="requiredBySenateOK"></span>
             <span class="requiredBySenate"></span>
             <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['learningActivities']}}"></i>
             <div id="formatActivities" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>                                        
-            </div>                                            
-            <textarea oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="52431" id = "learningActivities" data-formatnoteid="formatActivities" placeholder="E.g. Class participation consists of clicker questions, group discussions ... &#10;E.g. Students are expected to complete class pre-readings ..."name = "learningActivities" class ="form-control" type="date" style="height:125px;" form="sylabusGenerator" spellcheck="true">{{ !empty($syllabus) ? $syllabus->learning_activities : ''}}</textarea>
+                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+            </div>
+            <textarea oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="52431" id="learningActivities" data-formatnoteid="formatActivities" placeholder="E.g. Class participation consists of clicker questions, group discussions ... &#10;E.g. Students are expected to complete class pre-readings ..." name="learningActivities" class="form-control" type="date" style="height:125px;" form="sylabusGenerator" spellcheck="true">{{ !empty($syllabus) ? $syllabus->learning_activities : ''}}</textarea>
         </div>
         <!-- Course Learning Materials -->
         <div class="col-12">
-            <label for="learningMaterials"><h5 class="fw-bold">Learning Materials</h5></label><span class="requiredBySenateOK"></span>
+            <label for="learningMaterials">
+                <h5 class="fw-bold">Learning Materials</h5>
+            </label><span class="requiredBySenateOK"></span>
             <span class="requiredBySenate"></span>
             <p class="inputFieldDescription">{!! $inputFieldDescriptions['learningMaterials'] !!}</p>
             <div id="formatLM" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
                 <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
                     on a new line for the best formatting
                     results.</span>
-                </div>
+            </div>
             <textarea data-formatnoteid="formatLM" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000"
                 id="learningMaterials" name="learningMaterials" class="form-control" type="date" form="sylabusGenerator"
                 spellcheck="true">{{ !empty($syllabus) ? $syllabus->learning_materials : ''}}</textarea>
         </div>
-        
-    
+
+
         <div class="col-12">
-            <label for="learningAssessments"><h5 class="fw-bold">Methods of Assessment</h5></label><span class="requiredBySenateOK"></span>
+            <label for="learningAssessments">
+                <h5 class="fw-bold">Methods of Assessment</h5>
+            </label><span class="requiredBySenateOK"></span>
             <span class="requiredBySenate"></span>
             <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['learningAssessments']}}"></i>
             <div id="formatAssessments" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>                                        
-            </div>                                            
-            <textarea oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id = "learningAssessments" data-formatnoteid="formatAssessments" placeholder="E.g. Presentation, 25%, Dec 1, ... &#10;E.g. Midterm Exam, 25%, Sept 31, ..." name = "learningAssessments" class ="form-control" type="date" style="height:125px;" form="sylabusGenerator" spellcheck="true">{{ !empty($syllabus) ? $syllabus->learning_assessments : ''}}</textarea>
+                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+            </div>
+            <textarea oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="learningAssessments" data-formatnoteid="formatAssessments" placeholder="E.g. Presentation, 25%, Dec 1, ... &#10;E.g. Midterm Exam, 25%, Sept 31, ..." name="learningAssessments" class="form-control" type="date" style="height:125px;" form="sylabusGenerator" spellcheck="true">{{ !empty($syllabus) ? $syllabus->learning_assessments : ''}}</textarea>
         </div>
 
-       
+
 
         <!-- Course Structure -->
         <div class="col-12" id="courseStructure"></div>
-        
+
 
 
         @if (isset($courseAlignment))
-            <div class="p-0 m-0" id="courseAlignment"> 
-                <h5 class="fw-bold pt-4 mb-2 col-12 pt-4 mb-4 mt-2">
-                    Course Alignment                                     
-                    <button id="removeCourseAlignment" type="button" class="btn btn-danger float-right" onclick="removeSection(this)">Remove Section</button>
-                    <input hidden name="import_course_settings[courseId]" value="{{$syllabus->course_id}}">
-                    <input hidden name="import_course_settings[importCourseAlignment]" value="{{$syllabus->course_id}}">
-                    
+        <div class="p-0 m-0" id="courseAlignment">
+            <h5 class="fw-bold pt-4 mb-2 col-12 pt-4 mb-4 mt-2">
+                Course Alignment
+                <button id="removeCourseAlignment" type="button" class="btn btn-danger float-right" onclick="removeSection(this)">Remove Section</button>
+                <input hidden name="import_course_settings[courseId]" value="{{$syllabus->course_id}}">
+                <input hidden name="import_course_settings[importCourseAlignment]" value="{{$syllabus->course_id}}">
 
-                </h5>            
-                <div class="col-12" id="courseAlignmentTable">
-                    <table class="table table-light table-bordered table " >
+
+            </h5>
+            <div class="col-12" id="courseAlignmentTable">
+                <table class="table table-light table-bordered table ">
+                    <thead>
+                        <tr class="table-primary">
+                            <th class="w-50">Course Learning Outcome</th>
+                            <th>Student Assessment Method</th>
+                            <th>Teaching and Learning Activity</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($courseAlignment as $clo)
+                        <tr>
+                            <td scope="row">
+                                <b>{{$clo->clo_shortphrase}}</b><br>
+                                {{$clo->l_outcome}}
+                            </td>
+                            <td>{{$clo->assessmentMethods->implode('a_method', ', ')}}</td>
+                            <td>{{$clo->learningActivities->implode('l_activity', ', ')}}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @else
+        <div class="p-0 m-0" id="courseAlignment"></div>
+        @endif
+
+        @if (isset($outcomeMaps))
+        <div class="p-0 m-0" id="outcomeMapsDiv">
+            @foreach ($outcomeMaps as $programId => $outcomeMap)
+            <div class="p-0 m-0" id="outcomeMapsDiv">
+                <h5 class="fw-bold pt-4 mb-2 col-12 pt-4 mb-4 mt-2">
+                    {{$outcomeMap["program"]->program}}
+                    <button type="button" class="btn btn-danger float-right" onclick="removeSection(this)">Remove Section</button>
+                    <input hidden name="import_course_settings[programs][]" value="{{$programId}}">
+                </h5>
+
+                @if ($outcomeMap['program']->mappingScaleLevels->count() < 1)
+                    <div class="col-12">
+                    <div class="alert alert-warning wizard">
+                        <i class="bi bi-exclamation-circle-fill"></i>A mapping scale has not been set for this program.
+                    </div>
+            </div>
+            @else
+            <div class="col-12">
+                <table class="table table-bordered table-light">
+                    <thead>
+                        <tr class="table-primary">
+                            <th colspan="2">Mapping Scale</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($outcomeMap['program']->mappingScaleLevels as $mappingScale)
+                        <tr>
+                            <td>
+                                <div style="background-color:{{$mappingScale->colour}};height: 10px; width: 10px;"></div>
+                                {{$mappingScale->title}}<br>
+                                ({{$mappingScale->abbreviation}})
+                            </td>
+                            <td>
+                                {{$mappingScale->description}}
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            @endif
+
+            @if (isset($outcomeMap['outcomeMap']) > 0)
+            <div class="col-12">
+                <div style="overflow: auto;">
+                    <table class="table table-bordered table-light">
                         <thead>
                             <tr class="table-primary">
-                                <th class="w-50">Course Learning Outcome</th>
-                                <th>Student Assessment Method</th>
-                                <th>Teaching and Learning Activity</th>
+                                <th colspan="1" class="w-auto">CLO</th>
+                                <th colspan="{{$outcomeMap['program']->programLearningOutcomes->count()}}">Program Learning Outcome</th>
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach ($courseAlignment as $clo)
-                                <tr>
-                                    <td scope="row">
-                                        <b>{{$clo->clo_shortphrase}}</b><br>
-                                        {{$clo->l_outcome}}
-                                    </td>
-                                    <td>{{$clo->assessmentMethods->implode('a_method', ', ')}}</td>
-                                    <td>{{$clo->learningActivities->implode('l_activity', ', ')}}</td>
-                                </tr>   
-                            @endforeach                 
+                            <tr>
+                                <th></th>
+                                @foreach ($outcomeMap['program']->ploCategories as $category)
+                                @if ($category->plos->count() > 0)
+                                <th class="table-active w-auto" colspan="{{$category->plos->count()}}" style="min-width:5%; white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{$category->plo_category}}</th>
+                                @endif
+                                @endforeach
+                                @if ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null)->count() > 0)
+                                <th class="table-active w-auto text-center" colspan="{{$outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null)->count()}}" style="min-width:5%; white-space:nowrap;overflow:hidden;text-overflow:ellipsis">Uncategorized PLOs</th>
+                                @endif
+                            </tr>
+                            <tr>
+                                <td></td>
+                                @foreach ($outcomeMap['program']->ploCategories as $category)
+                                @if ($category->plos->count() > 0)
+                                @foreach ($category->plos as $plo)
+                                <td style="height:0; text-align: left;">
+                                    @if ($plo->plo_shortphrase)
+                                    {{$plo->plo_shortphrase}}
+                                    @else
+                                    {{$plo->pl_outcome}}
+                                    @endif
+                                </td>
+                                @endforeach
+                                @endif
+                                @endforeach
+                                @if ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null)->count() > 0)
+                                @foreach ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null) as $uncategorizedPLO)
+                                <td style="height:0; text-align: left;">
+                                    @if ($uncategorizedPLO->plo_shortphrase)
+                                    {{$uncategorizedPLO->plo_shortphrase}}
+                                    @else
+                                    {{$uncategorizedPLO->pl_outcome}}
+                                    @endif
+                                </td>
+                                @endforeach
+                                @endif
+                            </tr>
+                            @foreach ($outcomeMap['clos'] as $clo)
+                            <tr>
+                                <td class="w-auto">
+                                    @if (isset($clo->clo_shortphrase))
+                                    {{$clo->clo_shortphrase}}
+                                    @else
+                                    {{$clo->l_outcome}}
+                                    @endif
+                                </td>
+                                @foreach ($outcomeMap['program']->ploCategories as $category)
+                                @if ($category->plos->count() > 0)
+                                @foreach ($category->plos as $plo)
+                                @if (!array_key_exists($plo->pl_outcome_id, $outcomeMap['outcomeMap']))
+                                <td></td>
+                                @else
+                                @if (!array_key_exists($clo->l_outcome_id, $outcomeMap['outcomeMap'][$plo->pl_outcome_id]))
+                                <td></td>
+                                @else
+                                <td class="text-center align-middle" style="background-color:{{$outcomeMap['outcomeMap'][$plo->pl_outcome_id][$clo->l_outcome_id]->colour}}">{{$outcomeMap['outcomeMap'][$plo->pl_outcome_id][$clo->l_outcome_id]->abbreviation}}</td>
+                                @endif
+                                @endif
+                                @endforeach
+                                @endif
+                                @endforeach
+                                @if ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null)->count() > 0)
+                                @foreach ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null) as $uncategorizedPLO)
+                                @if (!array_key_exists($uncategorizedPLO->pl_outcome_id, $outcomeMap['outcomeMap']))
+                                <td></td>
+                                @else
+                                @if (!array_key_exists($clo->l_outcome_id, $outcomeMap['outcomeMap'][$uncategorizedPLO->pl_outcome_id]))
+                                <td></td>
+                                @else
+                                <td class="text-center align-middle" style="background-color:{{$outcomeMap['outcomeMap'][$uncategorizedPLO->pl_outcome_id][$clo->l_outcome_id]->colour}}">{{$outcomeMap['outcomeMap'][$uncategorizedPLO->pl_outcome_id][$clo->l_outcome_id]->abbreviation}}</td>
+                                @endif
+                                @endif
+                                @endforeach
+                                @endif
+                            </tr>
+                            @endforeach
                         </tbody>
                     </table>
                 </div>
             </div>
-        @else 
-            <div class="p-0 m-0" id="courseAlignment"></div>    
-        @endif
-
-        @if (isset($outcomeMaps))
-            <div class="p-0 m-0" id="outcomeMapsDiv">  
-                @foreach ($outcomeMaps as $programId => $outcomeMap)
-                    <div class="p-0 m-0" id="outcomeMapsDiv"> 
-                        <h5 class="fw-bold pt-4 mb-2 col-12 pt-4 mb-4 mt-2">
-                            {{$outcomeMap["program"]->program}}                 
-                            <button type="button" class="btn btn-danger float-right" onclick="removeSection(this)">Remove Section</button>
-                            <input hidden name="import_course_settings[programs][]" value="{{$programId}}">
-                        </h5>  
-
-                        @if ($outcomeMap['program']->mappingScaleLevels->count() < 1)
-                            <div class="col-12">
-                                <div class="alert alert-warning wizard">
-                                    <i class="bi bi-exclamation-circle-fill"></i>A mapping scale has not been set for this program.                  
-                                </div>
-                            </div>
-                        @else 
-                            <div class="col-12">
-                                <table class="table table-bordered table-light">
-                                    <thead>
-                                        <tr class="table-primary">
-                                            <th colspan="2">Mapping Scale</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        @foreach ($outcomeMap['program']->mappingScaleLevels as $mappingScale)
-                                            <tr>
-                                                <td>
-                                                <div style="background-color:{{$mappingScale->colour}};height: 10px; width: 10px;"></div>
-                                                    {{$mappingScale->title}}<br>
-                                                    ({{$mappingScale->abbreviation}})
-                                                </td>
-                                                <td>
-                                                    {{$mappingScale->description}}
-                                                </td>
-                                            </tr>
-                                        @endforeach
-                                    </tbody>
-                                </table>
-                            </div>
-                        @endif
-
-                        @if (isset($outcomeMap['outcomeMap']) > 0)
-                            <div class="col-12">
-                                <div style="overflow: auto;">
-                                    <table class="table table-bordered table-light">
-                                        <thead>
-                                            <tr class="table-primary">
-                                                <th colspan="1" class="w-auto">CLO</th>
-                                                <th colspan="{{$outcomeMap['program']->programLearningOutcomes->count()}}">Program Learning Outcome</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <th></th>
-                                                @foreach ($outcomeMap['program']->ploCategories as $category)
-                                                    @if ($category->plos->count() > 0)
-                                                        <th class="table-active w-auto" colspan="{{$category->plos->count()}}" style="min-width:5%; white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{$category->plo_category}}</th>  
-                                                    @endif          
-                                                @endforeach
-                                                @if ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null)->count() > 0)
-                                                    <th class="table-active w-auto text-center" colspan="{{$outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null)->count()}}" style="min-width:5%; white-space:nowrap;overflow:hidden;text-overflow:ellipsis">Uncategorized PLOs</th>
-                                                @endif
-                                            </tr> 
-                                            <tr>
-                                                <td></td>
-                                                @foreach ($outcomeMap['program']->ploCategories as $category)
-                                                    @if ($category->plos->count() > 0)
-                                                        @foreach ($category->plos as $plo)
-                                                            <td style="height:0; text-align: left;">
-                                                                @if ($plo->plo_shortphrase)
-                                                                    {{$plo->plo_shortphrase}}
-                                                                @else 
-                                                                    {{$plo->pl_outcome}}
-                                                                @endif
-                                                            </td>
-                                                        @endforeach
-                                                    @endif
-                                                @endforeach
-                                                @if ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null)->count() > 0)
-                                                    @foreach ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null) as $uncategorizedPLO)
-                                                        <td style="height:0; text-align: left;">
-                                                            @if ($uncategorizedPLO->plo_shortphrase)
-                                                                {{$uncategorizedPLO->plo_shortphrase}}
-                                                            @else 
-                                                                {{$uncategorizedPLO->pl_outcome}}
-                                                            @endif
-                                                        </td>
-                                                    @endforeach
-                                                @endif
-                                            </tr>
-                                            @foreach ($outcomeMap['clos'] as $clo) 
-                                                <tr>
-                                                    <td class="w-auto"> 
-                                                        @if (isset($clo->clo_shortphrase))
-                                                            {{$clo->clo_shortphrase}}
-                                                        @else 
-                                                            {{$clo->l_outcome}}
-                                                        @endif
-                                                    </td>
-                                                    @foreach ($outcomeMap['program']->ploCategories as $category)
-                                                        @if ($category->plos->count() > 0)
-                                                            @foreach ($category->plos as $plo)
-                                                                @if (!array_key_exists($plo->pl_outcome_id, $outcomeMap['outcomeMap']))
-                                                                    <td></td>
-                                                                @else 
-                                                                    @if (!array_key_exists($clo->l_outcome_id, $outcomeMap['outcomeMap'][$plo->pl_outcome_id]))
-                                                                        <td></td>
-                                                                    @else 
-                                                                        <td class="text-center align-middle" style="background-color:{{$outcomeMap['outcomeMap'][$plo->pl_outcome_id][$clo->l_outcome_id]->colour}}">{{$outcomeMap['outcomeMap'][$plo->pl_outcome_id][$clo->l_outcome_id]->abbreviation}}</td>
-                                                                    @endif
-                                                                @endif
-                                                            @endforeach
-                                                        @endif
-                                                    @endforeach
-                                                    @if ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null)->count() > 0)
-                                                        @foreach ($outcomeMap['program']->programLearningOutcomes->where('plo_category_id', null) as $uncategorizedPLO)
-                                                            @if (!array_key_exists($uncategorizedPLO->pl_outcome_id, $outcomeMap['outcomeMap']))
-                                                                <td></td>
-                                                            @else 
-                                                                @if (!array_key_exists($clo->l_outcome_id, $outcomeMap['outcomeMap'][$uncategorizedPLO->pl_outcome_id]))
-                                                                    <td></td>
-                                                                @else 
-                                                                    <td class="text-center align-middle" style="background-color:{{$outcomeMap['outcomeMap'][$uncategorizedPLO->pl_outcome_id][$clo->l_outcome_id]->colour}}">{{$outcomeMap['outcomeMap'][$uncategorizedPLO->pl_outcome_id][$clo->l_outcome_id]->abbreviation}}</td>
-                                                                @endif
-                                                            @endif
-                                                        @endforeach
-                                                    @endif                                
-                                                </tr>
-                                            @endforeach 
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        @else 
-                            <div class="col-12">
-                                <div class="alert alert-warning wizard">
-                                    <i class="bi bi-exclamation-circle-fill"></i>Course learning outcomes have not been mapped to program learning outcomes for this program.                 
-                                </div>
-                            </div>
-                        @endif
-                    </div>
-                @endforeach
-            </div>  
-        @else 
-            <div class="p-0 m-0" id="outcomeMapsDiv"></div>    
-        @endif
-
-        <!-- learning analytics and learning resources OK -->
-        <div class="col-12">
-                    <!-- Course Learning Resources -->
-                    <label for="learningResources"><h5 class="fw-bold">Learning Resources</h5></label>
-            <span class="requiredBySenate"></span>
-            <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['learningResources']}}"></i>
-            <div id="formatLR" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
-                    on a new line for the best formatting
-                    results.</span>
-                </div> 
-            <textarea data-formatnoteid="formatLR" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="30000"
-                id="learningResources" name="learningResources" class="form-control" form="sylabusGenerator"
-                spellcheck="true">{{ !empty($syllabus) ? $syllabus->learning_resources : ''}}</textarea>
-        </div>
-
-        <!-- University Policies -->
-        <div class="col-12" id="uniPolicy"></div>
-        <br>
-        <div>
-        <h5 class="fw-bold">Other Course Policies</h5></label>
-            <br>
-            <!-- Late Policy -->
+            @else
             <div class="col-12">
-                <label for="latePolicy"><h7 class="fw-bold">Late Policy</h7></label>
-                <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['latePolicy']}}"></i>
-                <div id="formatLP" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                    <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
-                        on a new line for the best formatting
-                        results.</span>
-                    </div>
-                <textarea data-formatnoteid="formatLP" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="latePolicy"
-                    name="latePolicy" class="form-control" type="date" form="sylabusGenerator"
-                    spellcheck="true">{{ !empty($syllabus) ? $syllabus->late_policy : ''}}</textarea>
+                <div class="alert alert-warning wizard">
+                    <i class="bi bi-exclamation-circle-fill"></i>Course learning outcomes have not been mapped to program learning outcomes for this program.
+                </div>
             </div>
-            <br>
-            <!-- Course Missing Exam -->
-            <div class="col-12">
-                <label for="missingExam"><h7 class="fw-bold">Missed Exam Policy</h7></label>
-                <div id="formatME" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                    <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
-                        on a new line for the best formatting
-                        results.</span>
-                    </div> 
-                <textarea data-formatnoteid="formatME" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="missingExam"
-                    name="missingExam" class="form-control" type="date" form="sylabusGenerator"
-                    spellcheck="true">{{ !empty($syllabus) ? $syllabus->missed_exam_policy : ''}}</textarea>
-            </div>
-            <br>
-            <!-- Course Missed Activity Policy -->
-            <div class="col-12">
-                <label for="missingActivity"><h7 class="fw-bold">Missed Activity Policy</h7></label><span class="requiredBySenateOK"></span>
-                <p class="inputFieldDescription">{!! $inputFieldDescriptions['missedActivityPolicy'] !!}</p>
-                <div id="formatMAP" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                    <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
-                        on a new line for the best formatting
-                        results.</span>
-                    </div>
-                <textarea data-formatnoteid="formatMAP" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="missingActivity"
-                    name="missingActivity" class="form-control" type="date" form="sylabusGenerator"
-                    spellcheck="true">{{ !empty($syllabus) ? $syllabus->missed_activity_policy : ''}}</textarea>
-            </div>
-            <br>
-            <!-- Course Passing Criteria -->
-            <div class="col-12">
-                <label for="passingCriteria"><h7 class="fw-bold">Passing/Grading Criteria</h7></label>
-                <div id="formatPC" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                    <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
-                        on a new line for the best formatting
-                        results.</span>
-                    </div>
-                <textarea data-formatnoteid="formatPC" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="passingCriteria"
-                    name="passingCriteria" class="form-control" type="date" form="sylabusGenerator"
-                    spellcheck="true">{{ !empty($syllabus) ? $syllabus->passing_criteria : ''}}</textarea>
-            </div>
-        
-            <br>
-             <!-- learning analytics -->
-            <div class="col-12" id="learningAnalytics"></div>
-        </div>
-
-        <!-- Additional Course-Specific Information-->
-        <div class="col-12">
-            <h5 class="fw-bold">Additional Course-Specific Information</h5></label>
-            <p class="inputFieldDescription">{{$inputFieldDescriptions['customResource']}}</p> 
-                    <textarea data-formatnoteid="formatCS" style="height:25px;overflow:hidden;resize:none" oninput="validateMaxlength()" onpaste="validateMaxlength()" resize="none" maxlength="10000" id="customResourceTitle" 
-                    name="customResourceTitle" class="form-control" type="date" form="sylabusGenerator"
-                        spellcheck="true" placeholder="Title of Custom Section">{{ !empty($syllabus) ? $syllabus->custom_resource_title : ''}}</textarea>
-                    <br>
-                    <div id="formatCS" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                    <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
-                        on a new line for the best formatting
-                        results.</span>
-                    </div>
-                    <textarea data-formatnoteid="formatCS" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="customResource" 
-                    name="customResource" class="form-control" type="date" form="sylabusGenerator"
-                        spellcheck="true" placeholder="Body Content of Custom Section">{{ !empty($syllabus) ? $syllabus->custom_resource : ''}}</textarea>
-        </div>
-        <br>
-
-        <!-- Policies and Regulations -->
-
-        <div class="col-12" id="policiesAndRegulations"></div>
-
-        <!-- Statement of UBC Values -->
-
-        <div class="col-12" id="statementUBCValues"></div>
-
-        
-        <!-- Statement of Student Support -->
-
-        <div class="col-12" id="statementStudentSupport"></div>
-
-
-        <!-- Optional Statements -->
-        <div class="col-12" id="optionalStatements"></div>
-
-        <!-- Copyright Statement -->
-        <div class="col-12" id="crStatement"></div>
-        
-        <!-- Creative Commons -->
-        
-        <div class="col-12">
-        <label for="creativeCommons"><h5 class="fw-bold">Copyright Statement</h5></label>
-            <p class="inputFieldDescription">
-            @if(!empty($syllabus))
-                @if($syllabus->campus=="O")
-                    {!! $inputFieldDescriptions['creativeCommons'] !!}
-                @endif
             @endif
-            </p>
-                    @if(!empty($syllabus))
-                        @if($syllabus->copyright==null)
-                        <input type="radio" id="noneCopyright" name="copyright" value="2" style="margin-right: 8px;" form="sylabusGenerator" checked/>
-                        <label>None</label>
-                        @else
-                        <input type="radio" id="noneCopyright" name="copyright" value="2" style="margin-right: 8px" form="sylabusGenerator" />
-                        <label>None</label>
-                        @endif
-                        <br>
-                        @if($syllabus->copyright)
-                        <input type="radio" id="yesCopyright" name="copyright" value="1" style="margin-right: 8px" form="sylabusGenerator"checked/>
-                        <label>Include a Copyright Statement</label>
-                        <div id="copyrightEx">
-                            <blockquote> All materials of this course (course handouts, lecture slides, assessments, course readings, etc.) are the intellectual property of the Course Instructor or licensed to be used in this course by the copyright owner. Redistribution of these materials by any means without permission of the copyright holder(s) constitutes a breach of copyright and may lead to academic discipline.</blockquote>
-                        </div> 
-                        @else
-                        <input type="radio" id="yesCopyright" name="copyright" value="1" style="margin-right: 8px" form="sylabusGenerator"/>
-                        <label>Include a Copyright Statement</label>
-                        
-                        <div id="copyrightEx"></div>
-                        @endif
-        
-                    @if(!empty($syllabus))
-                        @if($syllabus->campus == "O")
-                            @if($syllabus->copyright==1 || !isset($syllabus->cc_license))
-                                <input type="radio" id="noCopyright" name="copyright" value="0" style="margin-right: 8px" form="sylabusGenerator"/>
+        </div>
+        @endforeach
+</div>
+@else
+<div class="p-0 m-0" id="outcomeMapsDiv"></div>
+@endif
+
+<!-- learning analytics and learning resources OK -->
+<div class="col-12">
+    <!-- Course Learning Resources -->
+    <label for="learningResources">
+        <h5 class="fw-bold">Learning Resources</h5>
+    </label>
+    <span class="requiredBySenate"></span>
+    <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['learningResources']}}"></i>
+    <div id="formatLR" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+        <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
+            on a new line for the best formatting
+            results.</span>
+    </div>
+    <textarea data-formatnoteid="formatLR" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="30000"
+        id="learningResources" name="learningResources" class="form-control" form="sylabusGenerator"
+        spellcheck="true">{{ !empty($syllabus) ? $syllabus->learning_resources : ''}}</textarea>
+</div>
+
+<!-- University Policies -->
+<div class="col-12" id="uniPolicy"></div>
+<br>
+<div>
+    <h5 class="fw-bold">Other Course Policies</h5></label>
+    <br>
+    <!-- Late Policy -->
+    <div class="col-12">
+        <label for="latePolicy">
+            <h7 class="fw-bold">Late Policy</h7>
+        </label>
+        <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="{{$inputFieldDescriptions['latePolicy']}}"></i>
+        <div id="formatLP" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+            <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
+                on a new line for the best formatting
+                results.</span>
+        </div>
+        <textarea data-formatnoteid="formatLP" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="latePolicy"
+            name="latePolicy" class="form-control" type="date" form="sylabusGenerator"
+            spellcheck="true">{{ !empty($syllabus) ? $syllabus->late_policy : ''}}</textarea>
+    </div>
+    <br>
+    <!-- Course Missing Exam -->
+    <div class="col-12">
+        <label for="missingExam">
+            <h7 class="fw-bold">Missed Exam Policy</h7>
+        </label>
+        <div id="formatME" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+            <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
+                on a new line for the best formatting
+                results.</span>
+        </div>
+        <textarea data-formatnoteid="formatME" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="missingExam"
+            name="missingExam" class="form-control" type="date" form="sylabusGenerator"
+            spellcheck="true">{{ !empty($syllabus) ? $syllabus->missed_exam_policy : ''}}</textarea>
+    </div>
+    <br>
+    <!-- Course Missed Activity Policy -->
+    <div class="col-12">
+        <label for="missingActivity">
+            <h7 class="fw-bold">Missed Activity Policy</h7>
+        </label><span class="requiredBySenateOK"></span>
+        <p class="inputFieldDescription">{!! $inputFieldDescriptions['missedActivityPolicy'] !!}</p>
+        <div id="formatMAP" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+            <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
+                on a new line for the best formatting
+                results.</span>
+        </div>
+        <textarea data-formatnoteid="formatMAP" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="missingActivity"
+            name="missingActivity" class="form-control" type="date" form="sylabusGenerator"
+            spellcheck="true">{{ !empty($syllabus) ? $syllabus->missed_activity_policy : ''}}</textarea>
+    </div>
+    <br>
+    <!-- Course Passing Criteria -->
+    <div class="col-12">
+        <label for="passingCriteria">
+            <h7 class="fw-bold">Passing/Grading Criteria</h7>
+        </label>
+        <div id="formatPC" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+            <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
+                on a new line for the best formatting
+                results.</span>
+        </div>
+        <textarea data-formatnoteid="formatPC" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="passingCriteria"
+            name="passingCriteria" class="form-control" type="date" form="sylabusGenerator"
+            spellcheck="true">{{ !empty($syllabus) ? $syllabus->passing_criteria : ''}}</textarea>
+    </div>
+
+    <br>
+    <!-- learning analytics -->
+    <div class="col-12" id="learningAnalytics"></div>
+</div>
+
+<!-- Additional Course-Specific Information-->
+<div class="col-12">
+    <h5 class="fw-bold">Additional Course-Specific Information</h5></label>
+    <p class="inputFieldDescription">{{$inputFieldDescriptions['customResource']}}</p>
+    <textarea data-formatnoteid="formatCS" style="height:25px;overflow:hidden;resize:none" oninput="validateMaxlength()" onpaste="validateMaxlength()" resize="none" maxlength="10000" id="customResourceTitle"
+        name="customResourceTitle" class="form-control" type="date" form="sylabusGenerator"
+        spellcheck="true" placeholder="Title of Custom Section">{{ !empty($syllabus) ? $syllabus->custom_resource_title : ''}}</textarea>
+    <br>
+    <div id="formatCS" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+        <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
+            on a new line for the best formatting
+            results.</span>
+    </div>
+    <textarea data-formatnoteid="formatCS" style="height:125px" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="10000" id="customResource"
+        name="customResource" class="form-control" type="date" form="sylabusGenerator"
+        spellcheck="true" placeholder="Body Content of Custom Section">{{ !empty($syllabus) ? $syllabus->custom_resource : ''}}</textarea>
+</div>
+<br>
+
+<!-- Policies and Regulations -->
+
+<div class="col-12" id="policiesAndRegulations"></div>
+
+<!-- Statement of UBC Values -->
+
+<div class="col-12" id="statementUBCValues"></div>
+
+
+<!-- Statement of Student Support -->
+
+<div class="col-12" id="statementStudentSupport"></div>
+
+
+<!-- Optional Statements -->
+<div class="col-12" id="optionalStatements"></div>
+
+<!-- Copyright Statement -->
+<div class="col-12" id="crStatement"></div>
+
+<!-- Creative Commons -->
+
+<div class="col-12">
+    <label for="creativeCommons">
+        <h5 class="fw-bold">Copyright Statement</h5>
+    </label>
+    <p class="inputFieldDescription">
+        @if(!empty($syllabus))
+        @if($syllabus->campus=="O")
+        {!! $inputFieldDescriptions['creativeCommons'] !!}
+        @endif
+        @endif
+    </p>
+    @if(!empty($syllabus))
+    @if($syllabus->copyright==null)
+    <input type="radio" id="noneCopyright" name="copyright" value="2" style="margin-right: 8px;" form="sylabusGenerator" checked />
+    <label>None</label>
+    @else
+    <input type="radio" id="noneCopyright" name="copyright" value="2" style="margin-right: 8px" form="sylabusGenerator" />
+    <label>None</label>
+    @endif
+    <br>
+    @if($syllabus->copyright)
+    <input type="radio" id="yesCopyright" name="copyright" value="1" style="margin-right: 8px" form="sylabusGenerator" checked />
+    <label>Include a Copyright Statement</label>
+    <div id="copyrightEx">
+        <blockquote> All materials of this course (course handouts, lecture slides, assessments, course readings, etc.) are the intellectual property of the Course Instructor or licensed to be used in this course by the copyright owner. Redistribution of these materials by any means without permission of the copyright holder(s) constitutes a breach of copyright and may lead to academic discipline.</blockquote>
+    </div>
+    @else
+    <input type="radio" id="yesCopyright" name="copyright" value="1" style="margin-right: 8px" form="sylabusGenerator" />
+    <label>Include a Copyright Statement</label>
+
+    <div id="copyrightEx"></div>
+    @endif
+
+    @if(!empty($syllabus))
+    @if($syllabus->campus == "O")
+    @if($syllabus->copyright==1 || !isset($syllabus->cc_license))
+    <input type="radio" id="noCopyright" name="copyright" value="0" style="margin-right: 8px" form="sylabusGenerator" />
+    @else
+    <input type="radio" id="noCopyright" name="copyright" value="0" style="margin-right: 8px" form="sylabusGenerator" checked />
+    @endif
+    <label>Include a Creative Commons Open Copyright License</label>
+    <div>
+        <div class="col-12">
+            <br>
+
+            <div id="creativeCommonsInput" class="col-12">
+                @if(isset($syllabus->cc_license))
+                <h6><strong><u>Select a Creative Commons License:</u></strong></h6>
+                <br>
+                <table>
+                    <tr>
+                        <td>
+                            @if($syllabus->cc_license == 'CC BY' || $syllabus->cc_license == NULL)
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY" style="margin-right: 8px" form="sylabusGenerator" checked />
                             @else
-                                <input type="radio" id="noCopyright" name="copyright" value="0" style="margin-right: 8px" form="sylabusGenerator" checked/>
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY" style="margin-right: 8px" form="sylabusGenerator" />
                             @endif
-                        <label>Include a Creative Commons Open Copyright License</label>
-                        <div> 
-                        <div class="col-12">
-                            <br>
-                        
-                            <div id="creativeCommonsInput" class="col-12">
-                        @if(isset($syllabus->cc_license))
-                            <h6><strong><u>Select a Creative Commons License:</u></strong></h6>
-                            <br>
-                                <table>
-                                    <tr>
-                                        <td>
-                                            @if($syllabus->cc_license == 'CC BY' || $syllabus->cc_license == NULL)
-                                                <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY" style="margin-right: 8px" form="sylabusGenerator" checked/>
-                                            @else
-                                                <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY" style="margin-right: 8px" form="sylabusGenerator"/>
-                                            @endif
-                                        </td>
-                                        <td>
-                                            <div class="col-12">
-                                                <strong>Attribution: </strong>
-                                                <strong>CC BY </strong> 
-                                                <br>
-                                                This license lets others distribute, remix, adapt, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.
-                                                <br>
-                                                <a href="https://creativecommons.org/licenses/by/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by/4.0/legalcode">View Legal Code</a>
-                                            </div>
-                                            <br>
-                                        <td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                        @if($syllabus->cc_license == 'CC BY-SA')
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-SA" style="margin-right: 8px" form="sylabusGenerator" checked/>
-                                        @else
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-SA" style="margin-right: 8px" form="sylabusGenerator"/>
-                                        @endif
-                                        </td>
-                                        <td>
-                                            <div class="col-12">
-                                                <strong>Attribution-ShareAlike: </strong>
-                                                <strong>CC BY-SA</strong>
-                                                <br>
-                                                This license lets others remix, adapt, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.
-                                                <br>
-                                                <a href="https://creativecommons.org/licenses/by-sa/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">View Legal Code</a>
-                                            </div>
-                                            <br>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                        @if ($syllabus->cc_license == 'CC BY-ND')
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-ND" style="margin-right: 8px" form="sylabusGenerator" checked/>
-                                        @else
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-ND" style="margin-right: 8px" form="sylabusGenerator"/>
-                                        @endif
-                                        </td>
-                                        <td>
-                                            <div class="col-12">
-                                                <strong>Attribution-NoDerivs: </strong>
-                                                <strong>CC BY-ND</strong>
-                                                <br>
-                                                This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.
-                                                <br>
-                                                <a href="https://creativecommons.org/licenses/by-nd/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-nd/4.0/legalcode">View Legal Code</a>
-                                            </div>
-                                            <br>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                        @if($syllabus->cc_license == 'CC BY-NC')
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC" style="margin-right: 8px" form="sylabusGenerator" checked/>
-                                        @else
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC" style="margin-right: 8px" form="sylabusGenerator"/>
-                                        @endif
-                                        </td>
-                                        <td>
-                                            <div class="col-12">
-                                                <strong>Attribution-NonCommercial: </strong>
-                                                <strong>CC BY-NC</strong>
-                                                <br>
-                                                This license lets others remix, adapt, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.
-                                                <br>
-                                                <a href="https://creativecommons.org/licenses/by-nc/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-nc/4.0/legalcode">View Legal Code</a>
-                                            </div>
-                                            <br>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                        @if($syllabus->cc_license == 'CC BY-NC-SA')
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC-SA" style="margin-right: 8px" form="sylabusGenerator" checked/>
-                                        @else
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC-SA" style="margin-right: 8px" form="sylabusGenerator"/>
-                                        @endif
-                                        </td>
-                                        <td>
-                                            <div class="col-12">
-                                                <strong>Attribution-NonCommercial: </strong>
-                                                <strong>CC BY-NC-SA</strong>
-                                                <br>
-                                                This license lets others remix, adapt, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.
-                                                <br>
-                                                <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode">View Legal Code</a>
-                                            </div>
-                                            <br>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                        @if($syllabus->cc_license == 'CC BY-NC-ND')
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC-ND" style="margin-right: 8px" form="sylabusGenerator" checked/>
-                                        @else
-                                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC-ND" style="margin-right: 8px" form="sylabusGenerator"/>
-                                        @endif
-                                        </td>
-                                        <td>
-                                            <div class="col-12">
-                                                <strong>Attribution-NonCommercial-NoDerivs: </strong>
-                                                <strong>CC BY-NC-ND</strong>
-                                                <br>
-                                                This license is the most restrictive of our six main licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.<br>
-                                                <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode">View Legal Code</a>
-                                            </div>
-                                            <br>
-                                        </td>
-                                    </tr>
-                                </table>
-                                @endif
-                                </div>
-                            
-                        </div>
-                        
-            </div>
-            @endif
-        @endif
-                        
-                    @else
-                        <input type="radio" id="noneCopyright" name="copyright" value="2" style="margin-right: 8px" form="sylabusGenerator" checked/>
-                        <label>None</label>
-                        <br>
-                        <input type="radio" id="yesCopyright" name="copyright" value="1" style="margin-right: 8px" form="sylabusGenerator"/>
-                        <label>Include a Copyright Statement</label>
-                        <div id="copyrightEx"></div>
-                        <input type="radio" id="noCopyright" name="copyright" value="0" style="margin-right: 8px" form="sylabusGenerator"/>
-                                <label>Include a Creative Commons Open Copyright License</label>
-                                <div class="col-12">
+                        </td>
+                        <td>
+                            <div class="col-12">
+                                <strong>Attribution: </strong>
+                                <strong>CC BY </strong>
                                 <br>
-                                    <div id="creativeCommonsInput" class="col-12">
-                                        </div>
-                                </div>
-                
-                    @endif
-        </div>
-          
-        <!-- Land Acknowledgement Statement -->
-        <div class="col-12" id="landAcknowledgement"></div>
-    </form>
-
-    <div class="m-3">
-        <div class="text-center row justify-content-center">
-            <div class="col-2" style="max-width:10%">
-                <button type="submit" form="sylabusGenerator" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Save my syllabus">
-                    <i class="btn btn-light rounded-circle m-2 text-secondary bi bi-clipboard2-check-fill"></i>
-                    <p style="font-size:12px" class="text-muted m-0">SAVE</p>
-                </button>
+                                This license lets others distribute, remix, adapt, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.
+                                <br>
+                                <a href="https://creativecommons.org/licenses/by/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by/4.0/legalcode">View Legal Code</a>
+                            </div>
+                            <br>
+                        <td>
+                    </tr>
+                    <tr>
+                        <td>
+                            @if($syllabus->cc_license == 'CC BY-SA')
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-SA" style="margin-right: 8px" form="sylabusGenerator" checked />
+                            @else
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-SA" style="margin-right: 8px" form="sylabusGenerator" />
+                            @endif
+                        </td>
+                        <td>
+                            <div class="col-12">
+                                <strong>Attribution-ShareAlike: </strong>
+                                <strong>CC BY-SA</strong>
+                                <br>
+                                This license lets others remix, adapt, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.
+                                <br>
+                                <a href="https://creativecommons.org/licenses/by-sa/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">View Legal Code</a>
+                            </div>
+                            <br>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            @if ($syllabus->cc_license == 'CC BY-ND')
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-ND" style="margin-right: 8px" form="sylabusGenerator" checked />
+                            @else
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-ND" style="margin-right: 8px" form="sylabusGenerator" />
+                            @endif
+                        </td>
+                        <td>
+                            <div class="col-12">
+                                <strong>Attribution-NoDerivs: </strong>
+                                <strong>CC BY-ND</strong>
+                                <br>
+                                This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.
+                                <br>
+                                <a href="https://creativecommons.org/licenses/by-nd/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-nd/4.0/legalcode">View Legal Code</a>
+                            </div>
+                            <br>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            @if($syllabus->cc_license == 'CC BY-NC')
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC" style="margin-right: 8px" form="sylabusGenerator" checked />
+                            @else
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC" style="margin-right: 8px" form="sylabusGenerator" />
+                            @endif
+                        </td>
+                        <td>
+                            <div class="col-12">
+                                <strong>Attribution-NonCommercial: </strong>
+                                <strong>CC BY-NC</strong>
+                                <br>
+                                This license lets others remix, adapt, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.
+                                <br>
+                                <a href="https://creativecommons.org/licenses/by-nc/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-nc/4.0/legalcode">View Legal Code</a>
+                            </div>
+                            <br>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            @if($syllabus->cc_license == 'CC BY-NC-SA')
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC-SA" style="margin-right: 8px" form="sylabusGenerator" checked />
+                            @else
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC-SA" style="margin-right: 8px" form="sylabusGenerator" />
+                            @endif
+                        </td>
+                        <td>
+                            <div class="col-12">
+                                <strong>Attribution-NonCommercial: </strong>
+                                <strong>CC BY-NC-SA</strong>
+                                <br>
+                                This license lets others remix, adapt, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.
+                                <br>
+                                <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode">View Legal Code</a>
+                            </div>
+                            <br>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            @if($syllabus->cc_license == 'CC BY-NC-ND')
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC-ND" style="margin-right: 8px" form="sylabusGenerator" checked />
+                            @else
+                            <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC-ND" style="margin-right: 8px" form="sylabusGenerator" />
+                            @endif
+                        </td>
+                        <td>
+                            <div class="col-12">
+                                <strong>Attribution-NonCommercial-NoDerivs: </strong>
+                                <strong>CC BY-NC-ND</strong>
+                                <br>
+                                This license is the most restrictive of our six main licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.<br>
+                                <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">View License Deed</a> | <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode">View Legal Code</a>
+                            </div>
+                            <br>
+                        </td>
+                    </tr>
+                </table>
+                @endif
             </div>
-            <!-- PDF Download Disabled while we investigate escaping issues -->
-            <!--
+
+        </div>
+
+    </div>
+    @endif
+    @endif
+
+    @else
+    <input type="radio" id="noneCopyright" name="copyright" value="2" style="margin-right: 8px" form="sylabusGenerator" checked />
+    <label>None</label>
+    <br>
+    <input type="radio" id="yesCopyright" name="copyright" value="1" style="margin-right: 8px" form="sylabusGenerator" />
+    <label>Include a Copyright Statement</label>
+    <div id="copyrightEx"></div>
+    <input type="radio" id="noCopyright" name="copyright" value="0" style="margin-right: 8px" form="sylabusGenerator" />
+    <label>Include a Creative Commons Open Copyright License</label>
+    <div class="col-12">
+        <br>
+        <div id="creativeCommonsInput" class="col-12">
+        </div>
+    </div>
+
+    @endif
+</div>
+
+<!-- Land Acknowledgement Statement -->
+<div class="col-12" id="landAcknowledgement"></div>
+</form>
+
+<div class="m-3">
+    <div class="text-center row justify-content-center">
+        <div class="col-2" style="max-width:10%">
+            <button type="submit" form="sylabusGenerator" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Save my syllabus">
+                <i class="btn btn-light rounded-circle m-2 text-secondary bi bi-clipboard2-check-fill"></i>
+                <p style="font-size:12px" class="text-muted m-0">SAVE</p>
+            </button>
+        </div>
+        <!-- PDF Download Disabled while we investigate escaping issues -->
+        <!--
             <div class="col-2" style="max-width:10%">
                 <button type="submit" name="download" value="pdf" form="sylabusGenerator"
                     class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip" data-bs-placement="bottom"
@@ -1163,64 +1193,63 @@
                 </button>
             </div>
             -->
-            <div class="col-2" style="max-width:10%">
-                <button type="submit" name="download" value="word" form="sylabusGenerator"
-                    class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip" data-bs-placement="bottom"
-                    title="Save and Download syllabus as Word"><i
-                        class="bi-file-earmark-word-fill text-primary btn btn-light rounded-circle m-2"></i></i>
-                    <p style="font-size:12px" class="text-muted m-0">WORD</p>
-                </button>
-            </div>
-            <div class="col-2" style="max-width:10%">
-                <span data-bs-toggle="modal" data-bs-target="#importExistingCourse">
-                    <button type="button" class="btn m-0 p-0" data-bs-toggle="tooltip"
-                        data-bs-placement="bottom" title="Import an existing course" style="background:none;border:none"><i
-                            class="text-secondary bi bi-box-arrow-in-down-left btn btn-light rounded-circle m-2"></i>
-                            <p style="font-size:12px" class="text-muted m-0">IMPORT</p>
-                        </button>
-                </span>
-            </div>
-    
-            @if (!empty($syllabus))
-                <div class="col-2" style="max-width:10%">
-                    <span data-bs-toggle="modal" data-bs-target="#addSyllabusCollaboratorsModal{{$syllabus->id}}">
-                        <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
-                            data-bs-placement="bottom" title="Add collaborators to my syllabus"><i
-                                class="text-primary bi bi-people-fill btn btn-light rounded-circle m-2"></i>
-                            <p style="font-size:12px" class="text-muted m-0">PEOPLE</p>
-                        </button>
-                    </span>
-                </div>
-        
-                @include('modals.duplicateModal', ['syllabus' => $syllabus])
-                <div class="col-2" style="max-width:10%">
-                    <span data-bs-toggle="modal" data-bs-target="#duplicateConfirmation">
-                        <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
-                            data-bs-placement="bottom" title="Make a copy of my syllabus"><i
-                                class="btn btn-light rounded-circle m-2 text-success bi bi-files"></i>
-                                <p style="font-size:12px" class="text-muted m-0">COPY</p>
-                        </button>
-                    </span>
-                </div>
-        
-                @include('modals.deleteModal', ['syllabus' => $syllabus])
-                <div class="col-2" style="max-width:10%">
-                    <span data-bs-toggle="modal" data-bs-target="#deleteSyllabusConfirmation">
-                        <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
-                            data-bs-placement="bottom" title="Delete my syllabus"><i class="btn btn-danger rounded-circle m-2 bi bi-trash-fill"></i>
-                            <p style="font-size:12px" class="text-muted m-0">DELETE</p>
-                        </button>
-                    </span>
-                </div>
-            @endif
+        <div class="col-2" style="max-width:10%">
+            <button type="submit" name="download" value="word" form="sylabusGenerator"
+                class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip" data-bs-placement="bottom"
+                title="Save and Download syllabus as Word"><i
+                    class="bi-file-earmark-word-fill text-primary btn btn-light rounded-circle m-2"></i></i>
+                <p style="font-size:12px" class="text-muted m-0">WORD</p>
+            </button>
         </div>
-    </div>  
+        <div class="col-2" style="max-width:10%">
+            <span data-bs-toggle="modal" data-bs-target="#importExistingCourse">
+                <button type="button" class="btn m-0 p-0" data-bs-toggle="tooltip"
+                    data-bs-placement="bottom" title="Import an existing course" style="background:none;border:none"><i
+                        class="text-secondary bi bi-box-arrow-in-down-left btn btn-light rounded-circle m-2"></i>
+                    <p style="font-size:12px" class="text-muted m-0">IMPORT</p>
+                </button>
+            </span>
+        </div>
+
+        @if (!empty($syllabus))
+        <div class="col-2" style="max-width:10%">
+            <span data-bs-toggle="modal" data-bs-target="#addSyllabusCollaboratorsModal{{$syllabus->id}}">
+                <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
+                    data-bs-placement="bottom" title="Add collaborators to my syllabus"><i
+                        class="text-primary bi bi-people-fill btn btn-light rounded-circle m-2"></i>
+                    <p style="font-size:12px" class="text-muted m-0">PEOPLE</p>
+                </button>
+            </span>
+        </div>
+
+        @include('modals.duplicateModal', ['syllabus' => $syllabus])
+        <div class="col-2" style="max-width:10%">
+            <span data-bs-toggle="modal" data-bs-target="#duplicateConfirmation">
+                <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
+                    data-bs-placement="bottom" title="Make a copy of my syllabus"><i
+                        class="btn btn-light rounded-circle m-2 text-success bi bi-files"></i>
+                    <p style="font-size:12px" class="text-muted m-0">COPY</p>
+                </button>
+            </span>
+        </div>
+
+        @include('modals.deleteModal', ['syllabus' => $syllabus])
+        <div class="col-2" style="max-width:10%">
+            <span data-bs-toggle="modal" data-bs-target="#deleteSyllabusConfirmation">
+                <button type="button" class="btn m-0 p-0" style="background:none;border:none" data-bs-toggle="tooltip"
+                    data-bs-placement="bottom" title="Delete my syllabus"><i class="btn btn-danger rounded-circle m-2 bi bi-trash-fill"></i>
+                    <p style="font-size:12px" class="text-muted m-0">DELETE</p>
+                </button>
+            </span>
+        </div>
+        @endif
+    </div>
+</div>
 </div>
 
 <script type="application/javascript">
-    
-    var syllabus = <?php echo json_encode($syllabus);?>;
-    var faculties = <?php echo json_encode($faculties);?>;
+    var syllabus = <?php echo json_encode($syllabus); ?>;
+    var faculties = <?php echo json_encode($faculties); ?>;
 
     var vFaculties = faculties.filter(item => {
         return item.campus_id === 1;
@@ -1228,11 +1257,11 @@
     var oFaculties = faculties.filter(item => {
         return item.campus_id === 2;
     });
-    var departments = <?php echo json_encode($departments);?>;
+    var departments = <?php echo json_encode($departments); ?>;
 
-    $(document).ready(function () {
+    $(document).ready(function() {
 
-        $(function () {
+        $(function() {
             $('[data-bs-toggle="popover"]').popover()
         })
 
@@ -1240,7 +1269,7 @@
 
 
         // event listener on select term dropdown
-        $('#courseSemester').on('change', function(event) { 
+        $('#courseSemester').on('change', function(event) {
             // insert a text input if user selects other
             if ($('#courseSemester').val() == 'O') {
                 $('#courseSemesterOther').html(`
@@ -1258,9 +1287,9 @@
 
         //event listener for Cross Listed
         $('#crossListed').on('change', function() {
-            if(this.checked){
+            if (this.checked) {
                 $('#crossListedCode').html(`
-                
+
                 <label for="courseCodeCL">Cross-Listed Course Code<span class="requiredField"></span></label>
             <input id = "courseCodeCL" pattern="[A-Za-z]+" minlength="1" name = "courseCodeCL" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="4" class ="form-control" type="text" placeholder="E.g. CPSC" required value="{{ !empty($syllabus) ? $syllabus->cross_listed_code : '' }}">
             <div class="invalid-tooltip">
@@ -1286,13 +1315,13 @@
             $('#copyrightEx').html(``);
             $('#creativeCommonsInput').html(``);
         });
-        
+
         $('#yesCopyright').on('click', function(event) {
             //mankey
-            $('#copyrightEx').html(` 
+            $('#copyrightEx').html(`
             <div>
                 <blockquote> All materials of this course (course handouts, lecture slides, assessments, course readings, etc.) are the intellectual property of the Course Instructor or licensed to be used in this course by the copyright owner. Redistribution of these materials by any means without permission of the copyright holder(s) constitutes a breach of copyright and may lead to academic discipline.</blockquote>
-            </div> 
+            </div>
             `);
             $('#creativeCommonsInput').html(``);
 
@@ -1301,7 +1330,7 @@
         $('#noCopyright').on('click', function(event) {
 
             $('#creativeCommonsInput').html(
-            `
+                `
                             <h6><strong><u>Select a Creative Commons License:</u></strong></h6>
                             <br>
                                 <table>
@@ -1388,7 +1417,7 @@
                                     <tr>
                                         <td>
                                             <input type="radio" id="creativeCommons" name="creativeCommons" value="CC BY-NC-ND" style="margin-right: 8px" form="sylabusGenerator"/>
-                
+
                                         </td>
                                         <td>
                                             <div class="col-12">
@@ -1406,12 +1435,12 @@
                                  `);
 
             $('#copyrightEx').html(``);
-            
+
         });
-        
-    
+
+
         // event listener on create course schedule submit form button
-        $('#createCourseScheduleTblForm').on('submit', function(event) { 
+        $('#createCourseScheduleTblForm').on('submit', function(event) {
             // prevent default submit procedure
             event.preventDefault();
             event.stopPropagation();
@@ -1420,7 +1449,7 @@
             var courseScheduleTblDiv = document.getElementById('courseScheduleTblDiv');
             // create table if it doesn't exist
             if (!document.getElementById('courseScheduleTbl')) {
-                // get num rows 
+                // get num rows
                 var numRows = event.target.elements.numRows.value;
                 // get num cols
                 var numCols = event.target.elements.numCols.value;
@@ -1432,7 +1461,7 @@
                 var tblHead = document.createElement('thead');
                 // create <tbody> element
                 var tblBody = document.createElement('tbody');
-                // iterate over rows 
+                // iterate over rows
                 for (let rowIndex = 0; rowIndex < parseInt(numRows) + 1; rowIndex++) {
                     // create <row> element
                     var row = document.createElement('tr');
@@ -1440,7 +1469,7 @@
                     // iterate over cols
 
                     for (let colIndex = 0; colIndex < parseInt(numCols) + 1; colIndex++) {
-                        
+
                         // create <textarea>
                         var inputCell = document.createElement('textarea');
                         inputCell.setAttribute('form', 'sylabusGenerator');
@@ -1462,10 +1491,10 @@
                                 // put inputCell in <th>
                                 headerCell.appendChild(inputCell);
                             }
-                            // put <th> in <row>                           
+                            // put <th> in <row>
                             row.appendChild(headerCell);
                         } else {
-                            // create <td> element 
+                            // create <td> element
                             var cell = document.createElement('td');
                             if (colIndex == 0) {
                                 cell.setAttribute('class', 'align-middle fs-5 draggable');
@@ -1473,7 +1502,7 @@
                                 cell.innerHTML = "↕";
                             } else {
                                 // set input attributes for data cells
-                                inputCell.setAttribute('placeholder', 'Data here ...');                        
+                                inputCell.setAttribute('placeholder', 'Data here ...');
                                 inputCell.setAttribute('name', 'courseScheduleTblRows[]');
                                 // put inputCell in <td>
                                 cell.appendChild(inputCell);
@@ -1493,7 +1522,7 @@
                         // style delete action icon
                         delAction.setAttribute('class', 'bi bi-x-circle-fill text-danger fs-4 btn');
                         // add on click listener to del row
-                        delAction.onclick = delCourseScheduleRow;                        
+                        delAction.onclick = delCourseScheduleRow;
                         // put <i> in <td>
                         actionsCell.appendChild(delAction);
                         // put actions cell in <row>
@@ -1511,7 +1540,7 @@
                 }
                 // put <thead> in <table>
                 tbl.appendChild(tblHead);
-                // put <tbody> in <table> 
+                // put <tbody> in <table>
                 tbl.appendChild(tblBody);
                 // put <table> in course schedule table div
                 courseScheduleTblDiv.appendChild(tbl);
@@ -1528,7 +1557,7 @@
         // event listener on delete course schedule button
         $('#delCourseScheduleBtn').on('click', function(event) {
             var courseScheduleTblDiv = document.getElementById('courseScheduleTblDiv');
-            // remove all child nodes 
+            // remove all child nodes
             $(courseScheduleTblDiv).empty();
             // show create a course schedule table button
             $('#createTableBtn').removeAttr('hidden');
@@ -1541,17 +1570,17 @@
 
 
         // event listener on add col buttons
-        $('.addCol').on('click', function (event) { 
-            // get the course schedule table 
+        $('.addCol').on('click', function(event) {
+            // get the course schedule table
             var courseScheduleTbl = document.getElementById('courseScheduleTbl');
             // if course schedule table exists, add col to the side indicated by the button clicked
             if (courseScheduleTbl) {
-                // get which side to add the col to 
+                // get which side to add the col to
                 var side = event.currentTarget.dataset.side;
-                // get the num of cols in the tbl 
+                // get the num of cols in the tbl
                 var numCols = courseScheduleTbl.rows[0].cells.length;
                 // add col if there are less than 6 cols
-                if (numCols < parseInt($('#courseScheduleTblColsCount').attr('max')) + 2) {  
+                if (numCols < parseInt($('#courseScheduleTblColsCount').attr('max')) + 2) {
                     // add a new <td> to each <row>
                     Array.from(courseScheduleTbl.rows).forEach((row, rowIndex) => {
                         // create a <textarea>
@@ -1568,7 +1597,7 @@
                             inputCell.setAttribute('placeholder', 'Column heading here ...');
                             inputCell.setAttribute('name', 'courseScheduleTblHeadings[]');
                         } else {
-                            inputCell.setAttribute('placeholder', 'Data here ...');                        
+                            inputCell.setAttribute('placeholder', 'Data here ...');
                             inputCell.setAttribute('name', 'courseScheduleTblRows[]');
                         }
                         // add column on the correct side
@@ -1585,7 +1614,7 @@
                                     newCell.appendChild(inputCell);
                                 }
                                 break;
-                            case 'right': 
+                            case 'right':
                                 // put <td> in <row> at the back (insert col on the right)
                                 newCell = row.insertCell(numCols - 1);
                                 // if header row, make sure new cell has <th> tags
@@ -1597,21 +1626,23 @@
                         }
                     });
                 } else {
-                    // 
+                    //
                     var popover = bootstrap.Popover.getInstance(event.currentTarget.parentNode);
                     popover.show();
                     // hide popover after 3 seconds
-                    setTimeout(function() { popover.hide(); }, 3000);
+                    setTimeout(function() {
+                        popover.hide();
+                    }, 3000);
                 }
             }
         });
 
         // event listener on delete column(s) button in course schedule table toolbar
         // updates the delCols confirmation modal with info about the columns
-        $('#delCols').on('click', function (event) {
-            // get the course schedule table 
+        $('#delCols').on('click', function(event) {
+            // get the course schedule table
             var courseScheduleTbl = document.getElementById('courseScheduleTbl');
-            // if table exists, update and show delCols confirmation modal 
+            // if table exists, update and show delCols confirmation modal
             if (courseScheduleTbl) {
                 // get modal for deleting cols
                 var delColsModalEl = document.getElementById('delColsModal');
@@ -1622,7 +1653,7 @@
                 $(courseScheduleTblColsListDiv).empty();
                 // get the column cells from the first row
                 var cols = courseScheduleTbl.rows[0].cells;
-                // foreach col create a checkbox with label and place it in the delColsModal 
+                // foreach col create a checkbox with label and place it in the delColsModal
                 Array.from(cols).forEach((col, colIndex) => {
                     // only add relevant col headers to del cols modal
                     if (colIndex < cols.length - 1 && colIndex > 0) {
@@ -1630,7 +1661,7 @@
                         var colDiv = document.createElement('div');
                         // add bootstrap form elements styling
                         colDiv.setAttribute('class', 'form-check form-check-inline');
-                        // create, style and set attributes for <input> 
+                        // create, style and set attributes for <input>
                         var colCheckbox = document.createElement('input');
                         colCheckbox.setAttribute('id', 'col-heading-' + (colIndex + 1).toString());
                         colCheckbox.setAttribute('type', 'checkbox');
@@ -1644,12 +1675,12 @@
                         var colLabel = document.createElement('label');
                         colLabel.setAttribute('for', 'col-heading-' + (colIndex + 1).toString());
                         colLabel.setAttribute('class', 'form-check-label');
-                        colLabel.innerHTML = (col.firstElementChild.value.length === 0) ? 'Column #' + (colIndex).toString() : col.firstElementChild.value; 
+                        colLabel.innerHTML = (col.firstElementChild.value.length === 0) ? 'Column #' + (colIndex).toString() : col.firstElementChild.value;
                         // put <input> in <div>
                         colDiv.appendChild(colCheckbox);
                         // put <label> in <div>
                         colDiv.appendChild(colLabel);
-                        // put inner <div> in outer <div> 
+                        // put inner <div> in outer <div>
                         courseScheduleTblColsListDiv.appendChild(colDiv);
                     }
                 });
@@ -1658,42 +1689,44 @@
             }
         });
 
-        $('#delColsForm').on('submit', function (event) {
+        $('#delColsForm').on('submit', function(event) {
             // prevent default submit procedure
             event.preventDefault();
-            event.stopPropagation(); 
-            // get del cols confirmation modal   
-            var delColsModal = bootstrap.Modal.getInstance(document.getElementById('delColsModal'));   
-            // get the columns to delete from the del cols confirmation form 
+            event.stopPropagation();
+            // get del cols confirmation modal
+            var delColsModal = bootstrap.Modal.getInstance(document.getElementById('delColsModal'));
+            // get the columns to delete from the del cols confirmation form
             var colsToDelete = $(this).serializeArray().map((input, index) => {
                 return input.value;
             });
-            // sort colsToDelete in descending order to ensure cols with the greatest positions are deleted first. 
-            colsToDelete.sort(function(a, b) {return b - a});
-            // get the course schedule table 
+            // sort colsToDelete in descending order to ensure cols with the greatest positions are deleted first.
+            colsToDelete.sort(function(a, b) {
+                return b - a
+            });
+            // get the course schedule table
             var courseScheduleTbl = document.getElementById('courseScheduleTbl');
             // if table exists, del specified cols
             if (courseScheduleTbl) {
-                // iterate over table rows 
+                // iterate over table rows
                 Array.from(courseScheduleTbl.rows).forEach((row, rowIndex) => {
                     // iterate over columns to delete
                     colsToDelete.forEach((colToDelete) => {
                         // delete cells from every row
                         row.deleteCell(colToDelete);
-                        
+
                     });
                 });
             }
             delColsModal.hide();
         });
 
-        $('.addRow').on('click', function (event) { 
-            // get the course schedule table 
+        $('.addRow').on('click', function(event) {
+            // get the course schedule table
             var courseScheduleTbl = document.getElementById('courseScheduleTbl');
 
-            // if course schedule table has been created 
+            // if course schedule table has been created
             if (courseScheduleTbl) {
-                // get which side to add the row to 
+                // get which side to add the row to
                 var side = event.currentTarget.dataset.side;
                 // get the number of cols in the tbl
                 var numCols = courseScheduleTbl.rows[0].cells.length;
@@ -1718,13 +1751,13 @@
                             let topRow = courseScheduleTbl.tBodies[0].insertRow(0);
                             // add a cell for each col to the new row
                             for (let colIndex = 0; colIndex < numCols - 1; colIndex++) {
-                                // create  <td> element 
+                                // create  <td> element
                                 var cell = document.createElement('td');
                                 if (colIndex == 0) {
                                     cell.setAttribute('class', 'align-middle fs-5 draggable');
                                     cell.addEventListener('mousedown', mouseDownHandler);
                                     cell.innerHTML = "↕";
-                                } else { 
+                                } else {
                                     // put inputCell in <td>
                                     cell.appendChild(inputCell.cloneNode());
                                 }
@@ -1740,7 +1773,7 @@
                             // style delete action icon
                             delAction.setAttribute('class', 'bi bi-x-circle-fill text-danger fs-4 btn');
                             // add on click listener to del row
-                            delAction.onclick = delCourseScheduleRow;                        
+                            delAction.onclick = delCourseScheduleRow;
                             // put <i> in <td>
                             actionsCell.appendChild(delAction);
                             // put actions cell in <row>
@@ -1758,7 +1791,7 @@
                                     cell.setAttribute('class', 'align-middle fs-5 draggable');
                                     cell.addEventListener('mousedown', mouseDownHandler);
                                     cell.innerHTML = "↕";
-                                } else { 
+                                } else {
                                     // put inputCell in <td>
                                     cell.appendChild(inputCell.cloneNode());
                                 }
@@ -1773,31 +1806,33 @@
                             // style delete action icon
                             delAction.setAttribute('class', 'bi bi-x-circle-fill text-danger fs-4 btn');
                             // add on click listener to del row
-                            delAction.onclick = delCourseScheduleRow;                        
+                            delAction.onclick = delCourseScheduleRow;
                             // put <i> in <td>
                             actionsCell.appendChild(delAction);
                             // put actions cell in <row>
                             bottomRow.appendChild(actionsCell);
                             break;
                         default:
-                            let row = courseScheduleTbl.insertRow();                
+                            let row = courseScheduleTbl.insertRow();
                     }
                 } else {
                     var popover = bootstrap.Popover.getInstance(event.currentTarget.parentNode);
                     popover.show();
                     // hide popover after 3 seconds
-                    setTimeout(function() { popover.hide(); }, 3000);
+                    setTimeout(function() {
+                        popover.hide();
+                    }, 3000);
                 }
             }
         });
 
-        // add on change event listener to campus select 
-        $('#campus').change(function(){
+        // add on change event listener to campus select
+        $('#campus').change(function() {
             onChangeCampus();
-            });
-        
+        });
+
         // use custom bootstrap input validation
-        $('#sylabusGenerator').submit(function(event){
+        $('#sylabusGenerator').submit(function(event) {
             var invalidFields = $('#sylabusGenerator :invalid');
             if (invalidFields.length > 0) {
                 event.preventDefault();
@@ -1806,12 +1841,12 @@
                     scrollTop: $(invalidFields[0]).offset().top - 100,
                 });
                 $(this).addClass('was-validated');
-            // all fields are valid
+                // all fields are valid
             } else {
                 $(this).removeClass('was-validated');
             }
         });
-        
+
         // add on click event listener to import course info button
         $('#importButton').click(importCourseInfo);
         // trigger campus dropdown change based on saved syllabus
@@ -1841,12 +1876,12 @@
             if (classMeetingDays.includes('Fri')) {
                 $('#friday').attr('checked', 'true');
             }
-			if (classMeetingDays.includes('Sat')) {
+            if (classMeetingDays.includes('Sat')) {
                 $('#saturday').attr('checked', 'true');
             }
         }
         // use event delegation to show format note on focus in
-        document.getElementById("sylabusGenerator").addEventListener('focusin', function (event) {
+        document.getElementById("sylabusGenerator").addEventListener('focusin', function(event) {
             var formatNoteId = event.target.dataset.formatnoteid;
             if (formatNoteId) {
                 var note = document.querySelector('#' + formatNoteId);
@@ -1855,12 +1890,12 @@
                 if (isCollapsed) {
                     expandSection(note);
                     note.setAttribute('data-collapsed', 'false');
-                } 
+                }
             }
         });
-        
+
         // use event delegation to hide format note on focus out
-        document.getElementById("sylabusGenerator").addEventListener('focusout', function (event) {
+        document.getElementById("sylabusGenerator").addEventListener('focusout', function(event) {
             var formatNoteId = event.target.dataset.formatnoteid;
             if (formatNoteId) {
                 var note = document.querySelector('#' + formatNoteId);
@@ -1884,9 +1919,9 @@
         // instantiate new bootstrap modal
         var delRowModal = new bootstrap.Modal(delRowModalEl);
         // set on click listener for delete confirmation
-        $('#delRowBtn').on('click', function (event) {
+        $('#delRowBtn').on('click', function(event) {
             // delete row
-            (submitter.target) ? $(submitter.target).parents('tr').remove() : $(submitter).parents('tr').remove();
+            (submitter.target) ? $(submitter.target).parents('tr').remove(): $(submitter).parents('tr').remove();
             // hide modal
             delRowModal.hide();
         });
@@ -1896,7 +1931,7 @@
     }
 
     function addInstructor() {
-        instructorHTML =   `
+        instructorHTML = `
         <div class="instructor row g-3 align-items-end m-0 p-0">
             <div class="col-5">
                 <label for="courseInstructor">Name<span class="requiredField"> *</span></label>
@@ -1913,7 +1948,7 @@
                     Please enter the instructors email.
                 </div>
             </div>
-            
+
             <div class="col-2">
                 <button type="button" class="btn btn-danger col" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Delete instructor" onclick="delInstructor(this)"><i class="bi bi-trash-fill"></i> Delete</button>
             </div>
@@ -1938,7 +1973,7 @@
             type: "GET",
             url: "/syllabusGenerator/import/course",
             data: {
-                course_id : course_id, 
+                course_id: course_id,
                 importCourseSettings: importCourseSettings
             },
             headers: {
@@ -1956,7 +1991,7 @@
             if (data.hasOwnProperty('l_outcomes')) {
                 var l_outcomes = data['l_outcomes'];
                 var l_outcomes_text = "";
-                for(var i = 0; i < l_outcomes.length; i++) {
+                for (var i = 0; i < l_outcomes.length; i++) {
                     l_outcomes_text += l_outcomes[i].l_outcome + "\n";
                 }
                 $('#learningOutcome').val(l_outcomes_text);
@@ -1972,7 +2007,7 @@
             if (data.hasOwnProperty('l_activities')) {
                 var l_activities = data['l_activities'];
                 var l_activities_text = "";
-                for(var i = 0; i < l_activities.length; i++) {
+                for (var i = 0; i < l_activities.length; i++) {
                     l_activities_text += l_activities[i].l_activity + "\n";
                 }
                 $('#learningActivities').val(l_activities_text);
@@ -1998,17 +2033,17 @@
     function getProgramOutcomeMapSectionHTML(clos, program) {
         headerHTML = `
             <h5 class="fw-bold pt-4 mb-2 col-12 pt-4 mb-4 mt-2">
-                ${program['programTitle']}                                    
+                ${program['programTitle']}
                 <button id="" type="button" class="btn btn-danger float-right" onclick="removeSection(this)">Remove Section</button>
                 <input hidden name="import_course_settings[programs][]" value="${program['programId']}">
             </h5>
         `;
         mappingScalesHTML = getMappingScalesHTML(program['mappingScales']);
         // return early without outcome map if no mapping scale has been set for this program
-        // if (program['mappingScales'].length < 1) 
+        // if (program['mappingScales'].length < 1)
         //     return `<div class="mb-4">${headerHTML + mappingScalesHTML}</div>`;
 
-        
+
         outcomeMapHTML = getProgramOutcomeMapHTML(program['programLearningOutcomes'], program['categories'], program['uncategorizedPlos'], clos, program['outcomeMap']);
 
         return `<div class="mb-4">${headerHTML + mappingScalesHTML + outcomeMapHTML}</div>`;
@@ -2016,20 +2051,20 @@
 
     function getProgramOutcomeMapHTML(plos, categories, uncategorizedPLOs, clos, outcomeMap) {
         if (outcomeMap.length == 0)
-            return `    
+            return `
                 <div class="col-12">
                     <div class="alert alert-warning wizard">
-                        <i class="bi bi-exclamation-circle-fill"></i>Course learning outcomes have not been mapped to program learning outcomes for this program.                 
+                        <i class="bi bi-exclamation-circle-fill"></i>Course learning outcomes have not been mapped to program learning outcomes for this program.
                     </div>
                 </div>`;
-        
+
         categoryHeaderCells = ``;
         categorizedPLOCells = ``;
         categorizedOutcomeMapCells = [];
         categories.forEach((category, categoryIndex) => {
             if (category['plos'].length > 0) {
                 th = `
-                    <th class="table-active w-auto" colspan="${category['plos'].length}" style="min-width:5%; white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${category['plo_category']}</th>            
+                    <th class="table-active w-auto" colspan="${category['plos'].length}" style="min-width:5%; white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${category['plo_category']}</th>
                 `;
                 categoryHeaderCells += th;
                 category['plos'].forEach((plo, index) => {
@@ -2050,7 +2085,7 @@
                         if (!categorizedOutcomeMapCells[clo['l_outcome_id']])
                             categorizedOutcomeMapCells[clo['l_outcome_id']] = '';
 
-                        if (outcomeMap.length < 1) 
+                        if (outcomeMap.length < 1)
                             categorizedOutcomeMapCells[clo['l_outcome_id']] += '<td></td>'
                         else {
                             mappingScale = outcomeMap[plo['pl_outcome_id']][clo['l_outcome_id']];
@@ -2061,9 +2096,9 @@
                                 mapTd = `<td></td>`;
                                 categorizedOutcomeMapCells[clo['l_outcome_id']] += mapTd;
                             }
-                        }                            
+                        }
                     });
-                    
+
                     categorizedPLOCells += td;
                 })
             }
@@ -2094,7 +2129,7 @@
                     if (!uncategorizedOutcomeMapCells[clo['l_outcome_id']])
                         uncategorizedOutcomeMapCells[clo['l_outcome_id']] = '';
 
-                    if (outcomeMap.length < 1) 
+                    if (outcomeMap.length < 1)
                         uncategorizedOutcomeMapCells[clo['l_outcome_id']] += '<td></td>'
                     else {
                         if (!(plo['pl_outcome_id'] in outcomeMap)) {
@@ -2137,7 +2172,7 @@
         clos.forEach((clo, index) => {
             if (clo['clo_shortphrase'])
                 cloCellText = clo["clo_shortphrase"];
-            else 
+            else
                 cloCellText = clo["l_outcome"];
 
             if (!categorizedOutcomeMapCells[clo['l_outcome_id']])
@@ -2148,7 +2183,7 @@
 
             tr = `
                 <tr>
-                    <td class="w-auto"> 
+                    <td class="w-auto">
                         ${cloCellText}
                     </td>
                     ${categorizedOutcomeMapCells[clo['l_outcome_id']]}
@@ -2214,13 +2249,13 @@
                         </tbody>
                     </table>
                 </div>
-            `; 
+            `;
             return mappingScalesTableHTML;
         } else {
             noMappingScalesHTML = `
                 <div class="col-12">
                     <div class="alert alert-warning wizard">
-                        <i class="bi bi-exclamation-circle-fill"></i>A mapping scale has not been set for this program.                  
+                        <i class="bi bi-exclamation-circle-fill"></i>A mapping scale has not been set for this program.
                     </div>
                 </div>`;
             return noMappingScalesHTML;
@@ -2231,27 +2266,27 @@
     function getCourseAlignmentHTML(courseId, courseAlignment) {
         // course alignment table body
         tbody = ``;
-        courseAlignment.forEach(function(learningOutcome){
+        courseAlignment.forEach(function(learningOutcome) {
             // create comma separated string of asssessment methods
-            assessmentMethodsText = learningOutcome["assessment_methods"].reduce(function (acc, assessmentMethod, index) { 
-                if (index == 0) 
+            assessmentMethodsText = learningOutcome["assessment_methods"].reduce(function(acc, assessmentMethod, index) {
+                if (index == 0)
                     return acc + assessmentMethod['a_method'];
-                else 
+                else
                     return acc + ', ' + assessmentMethod['a_method']
             }, '');
             // create comma separated string of learning activities
-            learningActivitiesText = learningOutcome["learning_activities"].reduce(function (acc, learningActivity, index) { 
-                if (index == 0) 
+            learningActivitiesText = learningOutcome["learning_activities"].reduce(function(acc, learningActivity, index) {
+                if (index == 0)
                     return acc + learningActivity['l_activity'];
-                else 
+                else
                     return acc + ', ' + learningActivity['l_activity']
             }, '');
-        // course alignment table row
-        cloShortphraseHTML = '';
-        // check if clo shortphrase is null
-        if (learningOutcome['clo_shortphrase'])
-            cloShortphraseHTML = `<b>${learningOutcome['clo_shortphrase']}</b><br>`
-        row = `
+            // course alignment table row
+            cloShortphraseHTML = '';
+            // check if clo shortphrase is null
+            if (learningOutcome['clo_shortphrase'])
+                cloShortphraseHTML = `<b>${learningOutcome['clo_shortphrase']}</b><br>`
+            row = `
                 <tr>
                     <td scope="row">
                         ${cloShortphraseHTML}
@@ -2266,11 +2301,11 @@
         // course alignment section
         return `
             <h5 class="fw-bold pt-4 mb-2 col-12 pt-4 mb-4 mt-2">
-                Course Alignment                                     
+                Course Alignment
                 <button id="removeCourseAlignment" type="button" class="btn btn-danger float-right" onclick="removeSection(this)">Remove Section</button>
                 <input hidden name="import_course_settings[importCourseAlignment]" value="${courseId}">
 
-            </h5>            
+            </h5>
             <div class="col-12" id="courseAlignmentTable">
                 <table class="table table-light table-bordered table " >
                     <thead>
@@ -2288,14 +2323,14 @@
         `;
     }
 
-    function removeSection(btn){
+    function removeSection(btn) {
         $(btn.parentNode.parentNode).empty();
     }
 
     function expandSection(element) {
         // get the height of the element's inner content, regardless of its actual size
         var sectionHeight = element.scrollHeight;
-        
+
         // have the element transition to the height of its inner content
         element.style.height = sectionHeight + 'px';
 
@@ -2303,11 +2338,11 @@
         element.addEventListener('transitioned', function(e) {
             // remove this event listener so it only gets triggered once
             element.removeEventListener('transitioned', arguments.callee);
-            
+
             // remove "height" from the element's inline styles, so it can return to its initial value
             element.style.height = null;
         });
-        
+
         // mark the section as "currently not collapsed"
         element.setAttribute('data-collapsed', 'false');
     }
@@ -2319,21 +2354,21 @@
         // temporarily disable all css transitions
         var elementTransition = element.style.transition;
         element.style.transition = '';
-        
+
         // on the next frame (as soon as the previous style change has taken effect),
-        // explicitly set the element's height to its current pixel height, so we 
+        // explicitly set the element's height to its current pixel height, so we
         // aren't transitioning out of 'auto'
         requestAnimationFrame(function() {
             element.style.height = sectionHeight + 'px';
             element.style.transition = elementTransition;
-            
+
             // on the next frame (as soon as the previous style change has taken effect),
             // have the element transition to height: 0
             requestAnimationFrame(function() {
-            element.style.height = 0 + 'px';
+                element.style.height = 0 + 'px';
             });
         });
-        
+
         // mark the section as "currently collapsed"
         element.setAttribute('data-collapsed', 'true');
     }
@@ -2341,16 +2376,14 @@
     // Function changes optional verison of syllabus
     function onChangeCampus() {
 
-        $('.courseInfo').tooltip(
-            {
-                selector: '.has-tooltip'
-            }     
-        );
+        $('.courseInfo').tooltip({
+            selector: '.has-tooltip'
+        });
 
-       
+
         //different statements for each campus
         var okanaganCourseDescription = `
-            
+
                 <label for="courseDescription"><h5 class="fw-bold">Course Description</h5></label><span class="requiredBySenateOK"></span>
                 <p class="inputFieldDescription">{!! $inputFieldDescriptions['okanaganCourseDescription'] !!}</p>
                 <div id="formatDesc" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
@@ -2359,35 +2392,35 @@
                     results.</span>
                 </div>
                 <textarea style="height:125px" maxlength="7500" oninput="validateMaxlength()" onpaste="validateMaxlength()"  name = "courseDesc" class ="form-control" type="date" data-formatnoteid="formatDesc" form="sylabusGenerator">{{isset($okanaganSyllabus) ? $okanaganSyllabus->course_description : ''}}</textarea>`;
-                
 
-        
+
+
         var vancouverOptionalListDesc = `
             <p class="inputFieldDescription">
                 The below are suggested sections to include in your syllabus which communicate various resources on campus that support student success.
                 <a href="https://senate.ubc.ca/policies-resources-support-student-success/" target="_blank" rel="noopener noreferrer">Language taken from the UBC Vancouver senate website.</a>
             </p>`;
-        
+
         var okanaganOptionalListDesc = `
             <p class="inputFieldDescription">
                 The below are suggested sections to include in your syllabus which communicate various resources on campus that support student success.
                 <a href="https://senate.ubc.ca/okanagan/forms/" target="_blank" rel="noopener noreferrer">Language taken from the UBC Okanagan senate website</a> and other campus partners. Instructors may choose to add or edit this content as relevant.
             </p>`;
 
-         // list of vancouver syllabus resources
+        // list of vancouver syllabus resources
         var vancouverOptionalList = `
-            @if (!isset($selectedVancouverSyllabusResourceIds)) 
+            @if (!isset($selectedVancouverSyllabusResourceIds))
                 @foreach($vancouverSyllabusResources as $index => $vSyllabusResource)
                     <div class="col-6">
                         <input class="form-check-input " id="{{$vSyllabusResource->id_name}}" type="checkbox" name="vancouverSyllabusResources[{{$vSyllabusResource->id}}]" value="{{$vSyllabusResource->id_name}}" checked>
-                        <label class="form-check-label mb-2" for="{{$vSyllabusResource->id_name}}">{{$vSyllabusResource->title}}</label>   
+                        <label class="form-check-label mb-2" for="{{$vSyllabusResource->id_name}}">{{$vSyllabusResource->title}}</label>
                     </div>
                 @endforeach
             @else
                 @foreach($vancouverSyllabusResources as $index => $vSyllabusResource)
                     <div class="col-6">
                         <input class="form-check-input" id="{{$vSyllabusResource->id_name}}" type="checkbox" name="vancouverSyllabusResources[{{$vSyllabusResource->id}}]" value="{{$vSyllabusResource->id_name}}" {{in_array($vSyllabusResource->id, $selectedVancouverSyllabusResourceIds) ? 'checked' : ''}}>
-                        <label class="form-check-label  mb-2" for="{{$vSyllabusResource->id_name}}">{{$vSyllabusResource->title}}</label>   
+                        <label class="form-check-label  mb-2" for="{{$vSyllabusResource->id_name}}">{{$vSyllabusResource->title}}</label>
                     </div>
                 @endforeach
             @endif
@@ -2395,18 +2428,18 @@
             `;
         // list of okanagan syllabus resources
         var okanaganOptionalList = `
-            @if (!isset($selectedOkanaganSyllabusResourceIds)) 
+            @if (!isset($selectedOkanaganSyllabusResourceIds))
                 @foreach($okanaganSyllabusResources as $index => $oSyllabusResource)
                     <div class="col-6">
                         <input class="form-check-input " id="{{$oSyllabusResource->id_name}}" type="checkbox" name="okanaganSyllabusResources[{{$oSyllabusResource->id}}]" value="{{$oSyllabusResource->id_name}}" checked>
-                        <label class="form-check-label mb-2" for="{{$oSyllabusResource->id_name}}">{{$oSyllabusResource->title}}</label>   
+                        <label class="form-check-label mb-2" for="{{$oSyllabusResource->id_name}}">{{$oSyllabusResource->title}}</label>
                     </div>
                 @endforeach
             @else
                 @foreach($okanaganSyllabusResources as $index => $oSyllabusResource)
                     <div class="col-6 ">
                         <input class="form-check-input " id="{{$oSyllabusResource->id_name}}" type="checkbox" name="okanaganSyllabusResources[{{$oSyllabusResource->id}}]" value="{{$oSyllabusResource->id_name}}" {{in_array($oSyllabusResource->id, $selectedOkanaganSyllabusResourceIds) ? 'checked' : ''}}>
-                        <label class="form-check-label mb-2" for="{{$oSyllabusResource->id_name}}">{{$oSyllabusResource->title}}</label>   
+                        <label class="form-check-label mb-2" for="{{$oSyllabusResource->id_name}}">{{$oSyllabusResource->title}}</label>
                     </div>
                 @endforeach
             @endif
@@ -2419,7 +2452,7 @@
                 Please enter the course course credits.
             </div>
             `;
-        
+
         var officeLocation = `
             <label for="officeLocation">Office Location <span class="requiredField">*</span></label>
             <i class="bi bi-info-circle-fill has-tooltip"  data-bs-placement="right" title="{{$inputFieldDescriptions['officeLocation']}}"></i>
@@ -2431,11 +2464,11 @@
             `;
 
         var courseDescription = `
-            
+
                 <label for="courseDescription">Course Description</label>
                 <i class="bi bi-info-circle-fill has-tooltip"  data-bs-placement="right" title="{{$inputFieldDescriptions['courseDescription']}}"></i>
                 <textarea maxlength="7500" oninput="validateMaxlength()" onpaste="validateMaxlength()"  name = "courseDescription" class ="form-control" type="date" form="sylabusGenerator">{{isset($vancouverSyllabus) ? $vancouverSyllabus->course_description : ''}}</textarea>
-            
+
 
             `;
 
@@ -2444,8 +2477,8 @@
             <span class="requiredBySenate"></span>
             <p class="inputFieldDescription">{{$inputFieldDescriptions['courseContacts']}}</p>
             <div id="formatContacts" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>                                        
-            </div>                                            
+                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+            </div>
             <textarea style="height:125px" maxlength="7500" oninput="validateMaxlength()" onpaste="validateMaxlength()"  id="courseContacts" data-formatnoteid="formatContacts" name = "courseContacts" placeholder="E.g. Professor, Jane Doe, jane.doe@ubc.ca, +1 234 567 8900, ... &#10;Teaching Assistant, John Doe, john.doe@ubc.ca, ..."class ="form-control" type="date" form="sylabusGenerator">{{isset($vancouverSyllabus) ? $vancouverSyllabus->course_contacts : ''}}</textarea>
             `;
 
@@ -2454,8 +2487,8 @@
                 <span class="requiredBySenate"></span>
                 <p class="inputFieldDescription">{{$inputFieldDescriptions['coursePrereqs']}}</p>
                 <div id="formatPrereqs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
-                    <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>                                        
-                </div>                                            
+                    <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+                </div>
                 <textarea style="height:125px" maxlength="7500" oninput="validateMaxlength()" onpaste="validateMaxlength()"  id="coursePrereqs" data-formatnoteid="formatPrereqs"name = "coursePrereqs" placeholder="E.g. CPSC 210 or EECE 210 or CPEN 221 &#10;E.g. CPSC 121 or MATH 220"class ="form-control" type="text" form="sylabusGenerator" >{{isset($vancouverSyllabus) ? $vancouverSyllabus->course_prereqs : ''}}</textarea>
             `;
 
@@ -2464,8 +2497,8 @@
                 <span class="requiredBySenate"></span>
                 <p class="inputFieldDescription">{{$inputFieldDescriptions['courseCoreqs']}}</p>
                 <div id="formatCoreqs"class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false" >
-                    <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>                                        
-                </div>                                            
+                    <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+                </div>
                 <textarea style="height:125px" maxlength="7500" oninput="validateMaxlength()" onpaste="validateMaxlength()"  id = "courseCoreqs" data-formatnoteid="formatCoreqs"placeholder="E.g. CPSC 107 or CPSC 110 &#10;E.g. CPSC 210" name = "courseCoreqs" class ="form-control" type="text" form="sylabusGenerator">{{isset($vancouverSyllabus) ? $vancouverSyllabus->course_coreqs : ''}}</textarea>
             `;
         var courseInstructorBio = `
@@ -2475,11 +2508,11 @@
                 <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each paragraph
                     on a new line for the best formatting
                     results.</span>
-                </div> 
+                </div>
             <textarea data-formatnoteid="formatCIB" style="height:125px" maxlength="7500" oninput="validateMaxlength()" onpaste="validateMaxlength()"  id = "courseInstructorBio" name = "courseInstructorBio" class ="form-control" form="sylabusGenerator" spellcheck="true">{{isset($vancouverSyllabus) ? $vancouverSyllabus->instructor_bio : ''}}</textarea>
-            
-            `;     
-        
+
+            `;
+
         var courseStructure = `
                 <label for="courseStructure"><h5 class="fw-bold">Course Structure</h5></label>
                 <span class="requiredBySenate"></span>
@@ -2499,7 +2532,7 @@
                 <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i> <span class="fs-6">Place each entry
                     on a new line for the best formatting
                     results.</span>
-                </div> 
+                </div>
                 <textarea data-formatnoteid="formatLAnal" style="height:125px" maxlength="7500" oninput="validateMaxlength()" onpaste="validateMaxlength()"  id="learningAnalytics" name = "learningAnalytics" class ="form-control" type="text" form="sylabusGenerator">{{isset($vancouverSyllabus) ? $vancouverSyllabus->learning_analytics : ''}}</textarea>
             `;
         var courseFormat = `
@@ -2524,19 +2557,19 @@
 
         var requiredBySenateLabel = `
             <span class="d-inline-block has-tooltip ml-2 mr-2" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top" title="This section is required in your syllabus under Vancouver Senate policy V-130">
-                <button type="button" class="btn btn-danger btn-sm mb-2 disabled" style="font-size:10px;">Required by policy</button> 
+                <button type="button" class="btn btn-danger btn-sm mb-2 disabled" style="font-size:10px;">Required by policy</button>
             </span>
             `;
 
         var requiredBySenateLabelOK = `
             <span class="d-inline-block has-tooltip ml-2 mr-2" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top" title="This section is required in your syllabus under Okanagan Senate policy">
-                <button type="button" class="btn btn-danger btn-sm mb-2 disabled" style="font-size:10px;">Required by policy</button> 
+                <button type="button" class="btn btn-danger btn-sm mb-2 disabled" style="font-size:10px;">Required by policy</button>
             </span>
             `;
         var uniPolicyVan = `
             <label for="learningMaterials"><h5 class="fw-bold">University Policies</h5></label>
             <span class="requiredBySenate"></span>
-            <p class="inputFieldDescription">{!! $inputFieldDescriptions['uniPolicy'] !!}</p> 
+            <p class="inputFieldDescription">{!! $inputFieldDescriptions['uniPolicy'] !!}</p>
             <br>
             <div class="col-12">
             <blockquote> UBC provides resources to support student learning and to maintain healthy lifestyles but recognizes that sometimes crises arise and so there are additional resources to access including those for survivors of sexual violence. UBC values respect for the person and ideas of all members of the academic community. Harassment and discrimination are not tolerated nor is suppression of academic freedom. UBC provides appropriate accommodation for students with disabilities and for religious observances. UBC values academic honesty and students are expected to acknowledge the ideas generated by others and to uphold the highest academic standards in all of their actions.
@@ -2544,7 +2577,7 @@
             </div>
          `;
 
-         var crStatement = `
+        var crStatement = `
             <label for="copyright"><h5 class="fw-bold">© Copyright</h5></label>
             <br>
             <div class="col-12">
@@ -2556,13 +2589,13 @@
                     @else
                         <input class="form-check-input " id="copyright" type="checkbox" name="copyright" value="1">
                     @endif
-                    <label class="form-check-label mb-2" for="copyright">Include in Syllabus</label>   
+                    <label class="form-check-label mb-2" for="copyright">Include in Syllabus</label>
                 @endif
                 </div>
             </div>
          `;
 
-         var landAcknowledgementV = `
+        var landAcknowledgementV = `
             <label for="landAcknowledgement"><h5 class="fw-bold">Land Acknowledgement</h5></label>
             <br>
             <div class="col-12">
@@ -2574,16 +2607,16 @@
                     @else
                         <input class="form-check-input " id="landAck" type="checkbox" name="landAck" value="1">
                     @endif
-                    <label class="form-check-label mb-2" for="landAck">Include in Syllabus</label>  
+                    <label class="form-check-label mb-2" for="landAck">Include in Syllabus</label>
                 @else
                     <input class="form-check-input " id="landAck" type="checkbox" name="landAck" value="1">
-                    <label class="form-check-label mb-2" for="landAck">Include in Syllabus</label>  
+                    <label class="form-check-label mb-2" for="landAck">Include in Syllabus</label>
                 @endif
                 </div>
             </div>
          `;
 
-         var landAcknowledgementO = `
+        var landAcknowledgementO = `
             <label for="landAcknowledgement"><h5 class="fw-bold">Land Acknowledgement</h5></label>
             <br>
             <div class="col-12">
@@ -2595,31 +2628,31 @@
                     @else
                         <input class="form-check-input " id="landAck" type="checkbox" name="landAck" value="1">
                     @endif
-                    <label class="form-check-label mb-2" for="landAck">Include in Syllabus</label>  
+                    <label class="form-check-label mb-2" for="landAck">Include in Syllabus</label>
                 @else
                     <input class="form-check-input " id="landAck" type="checkbox" name="landAck" value="1">
-                    <label class="form-check-label mb-2" for="landAck">Include in Syllabus</label>  
+                    <label class="form-check-label mb-2" for="landAck">Include in Syllabus</label>
                 @endif
                 </div>
             </div>
          `;
 
-         var optionalStatements =`
+        var optionalStatements = `
 
          <h5  class="fw-bold">Additional UBC language regarding academic integrity, academic misconduct, and use of generative artificial intelligence (GenAI)</h5>
                 @if(!empty($syllabus))
                     <div id="optionalSyllabusDesc"></div>
                 @else
                     <p class="inputFieldDescription"> You may choose to add the below statements to your syllabi to clarify expectations in your course. For additional language available visit <a href="https://academicintegrity.ubc.ca/generative-ai-syllabus/">UBC's Academic Integrity website</a>.
-                        
+
                     </p>
                 @endif
             <div class="form-check m-4">
                 <div class="row" id="optionalSyllabus"></div>
             </div>
             `;
-            var statementUBCValues =`
-            
+        var statementUBCValues = `
+
             <label for="statementUBCValues"><h5 class="fw-bold">Statement of UBC Values</h5></label><span class="requiredBySenateOK"></span>
             <br>
             <div class="col-12">
@@ -2627,8 +2660,8 @@
             </div>
             `;
 
-            var statementStudentSupport =`
-            
+        var statementStudentSupport = `
+
             <label for="statementStudentSupport"><h5 class="fw-bold">Statement regarding Resources to Support Student Success</h5></label><span class="requiredBySenateOK"></span>
             <br>
             <div class="col-12">
@@ -2636,8 +2669,8 @@
             </div>
             `;
 
-            var policiesAndRegulations =`
-            
+        var policiesAndRegulations = `
+
             <label for="policiesAndRegulations"><h5 class="fw-bold">Statement on Policies and Regulations</h5></label><span class="requiredBySenateOK"></span>
             <br>
             <div class="col-12">
@@ -2645,14 +2678,14 @@
             </div>
             `;
 
-        var courseSectionOK =  `
+        var courseSectionOK = `
             <label for="endTime">Course Section</label>
             <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="20" id = "courseSection" name = "courseSection" class ="form-control" type="text" placeholder="E.g. 001" value="{{ !empty($syllabus) ? $syllabus->course_section : ''}}" >`;
-        
+
         // get campus select element
         var campus = $('#campus');
         // check if its value is 'V'
-        if(campus.val() == 'V'){
+        if (campus.val() == 'V') {
             // add data specific to vancouver campus
             //$('#optionalSyllabusDesc').html(vancouverOptionalListDesc);
             //$('#optionalSyllabus').html(vancouverOptionalList);
@@ -2674,7 +2707,7 @@
             //$('#crStatement').html(crStatement);
             $('#landAcknowledgement').html(landAcknowledgementV);
             $('.requiredBySenate').html(requiredBySenateLabel);
-           
+
 
             // remove data specific to okanangan campus
             $('#courseFormat').empty();
@@ -2688,11 +2721,14 @@
             $('#statementUBCValues').empty();
             $('#statementStudentSupport').empty();
             $('#policiesAndRegulations').empty();
+
+            // Hide prerequisites and corequisites inputs for Vancouver
+            $('#prerequisites').closest('.col-6').hide();
+            $('#corequisites').closest('.col-6').hide();
+
             // update faculty dropdown
             setFaculties('Vancouver');
-        }   
-        else
-        {
+        } else {
             // add data specific to okanagan campus
             $('#optionalStatements').html(optionalStatements);
             $('#optionalSyllabusDesc').html(okanaganOptionalListDesc);
@@ -2728,6 +2764,10 @@
             $('#crStatement').empty();
             $('#landAcknowledgement').html(landAcknowledgementO);
 
+            // Show prerequisites and corequisites inputs for Okanagan
+            $('#prerequisites').closest('.col-6').show();
+            $('#corequisites').closest('.col-6').show();
+
             // update faculty dropdown
             setFaculties('Okanagan');
         }
@@ -2750,7 +2790,7 @@
 
         placeholderFaculty = `<option value="" class="text-muted" > -- Faculty -- </option>`;
         placeholderDept = `<option value="" class="text-muted"> -- Department -- </option>`;
-        
+
         $('#faculty').append(placeholderFaculty);
         $('#department').append(placeholderDept);
 
@@ -2794,19 +2834,18 @@
 
         });
     }
-    
+
     //This method is used to make sure that the proper amount of characters are entered so it doesn't exceed the max character limits
-    function validateMaxlength(e){
+    function validateMaxlength(e) {
         //Whitespaces are counted as 1 but character wise are 2 (\n).
         var MAX_LENGTH = event.target.getAttribute("maxlength");
         var currentLength = event.target.value.length;
         var whiteSpace = event.target.value.split(/\n/).length;
-        if((currentLength+(whiteSpace))>MAX_LENGTH)
-        { 
+        if ((currentLength + (whiteSpace)) > MAX_LENGTH) {
             //Goes to MAX_LENGTH-(whiteSpace)+1 because it starts at 1
-            event.target.value = event.target.value.substr(0,MAX_LENGTH-(whiteSpace)+1);	        
+            event.target.value = event.target.value.substr(0, MAX_LENGTH - (whiteSpace) + 1);
         }
-    } 
+    }
 </script>
 <!-- Include script to reorder table rows-->
 <script src="{{ asset('js/drag_drop_tbl_row.js') }}"></script>


### PR DESCRIPTION
### Description
This PR eliminates the duplicate fields for prerequisites and corequisites in the Syllabus Generator when the Vancouver campus is selected. The existing section specific to the Vancouver campus will remain intact, ensuring clarity and consistency in the form.

### Changes Made
- **Removed** the upper duplicate input fields and their labels for prerequisites and corequisites when Vancouver campus is selected.
- **Kept** the existing section specific to the Vancouver campus for prerequisites and corequisites.

### Code Changes
The following changes were made to the relevant template:

```javascript
// Remove duplicate fields for Vancouver campus
// Existing code for specific prerequisites and corequisites for Vancouver campus remains intact
```

### Testing
- Please verify that the duplicate fields are no longer visible for the Vancouver campus while the specific section remains intact.
- Ensure that the prerequisites and corequisites are still displayed correctly for the Okanagan campus.

### Notes
- This change helps streamline the user interface by removing unnecessary duplication and reducing confusion.