### PR TITLE
Convert prerequisites and corequisites to table format export [OK]

### DIFF
--- a/app/Http/Controllers/SyllabusController.php
+++ b/app/Http/Controllers/SyllabusController.php
@@ -34,7 +34,7 @@ define('INPUT_TIPS', [
     'otherCourseStaff' => 'At the discretion of the course instructor, the names of any other student-facing members of teaching staff such as teaching assistants involved in the offering of the course (if not available on the Student Service Centre or on Workday), and details of when and by what means students may contact them.',
     'learningOutcomes' => 'i.e., what is to be achieved and assessed in the course.',
     'learningAssessments' => 'The methods used to assess achievement of stated learning outcomes or objectives, including the weighting of each component in the final grade.',
-    'learningActivities' => 'Do you expect students to participate in class? In what ways? (e.g., case studies, using “clickers” to answer questions, working in small groups, etc.) Is participation in on-line discussions required? Are readings required in advance with answers to be submitted to discussion questions or problem sets? 
+    'learningActivities' => 'Do you expect students to participate in class? In what ways? (e.g., case studies, using “clickers” to answer questions, working in small groups, etc.) Is participation in on-line discussions required? Are readings required in advance with answers to be submitted to discussion questions or problem sets?
     Is an oral presentation required? Is there a field excursion?',
     'learningMaterials' => 'List of required learning materials for your course (including textbooks, reading packages, on-line assessment tools, lab and field trip manuals) and where they might be obtained (e.g. the Bookstore if you ordered a text or a reading package, your department office if an in-house resource is available, the Library through their <a href="https://library.ok.ubc.ca/services/course-reserves/" target="_blank" rel="noopener noreferrer">course-reserve system</a>). Providing students with at least an estimate of the costs of materials is expected. Explanation of any on-line learning management system used (e.g.Canvas).',
     'latePolicy' => 'State your policies on re-grading of marked work and on late submissions. What are the penalties for late assignments?',
@@ -56,7 +56,7 @@ define('INPUT_TIPS', [
     'customResource' => 'Include any additional information or resources that have not been provided.',
     'saveWarning' => 'Be sure to save your content regularly by clicking the save button <i class="bi bi-clipboard2-check-fill"></i> at the top and bottom of this page.',
     'crossListed' => 'Is this a Cross-Listed Course? Per <a href="https://senate.ubc.ca/okanagan/forms/" target="_blank" rel="noopener noreferrer">Curriculum Guidelines</a>.',
-    'courseStructureOK' =>'A description of the course structure such as, for example, lecture, lab, tutorial, flipped classroom, mixed-mode, contact hours per week; day, time, and location of classes, or other activities that may not be available on the Student Service Centre or on Workday.'
+    'courseStructureOK' => 'A description of the course structure such as, for example, lecture, lab, tutorial, flipped classroom, mixed-mode, contact hours per week; day, time, and location of classes, or other activities that may not be available on the Student Service Centre or on Workday.'
 ]);
 
 class SyllabusController extends Controller
@@ -122,7 +122,7 @@ class SyllabusController extends Controller
 
             // show view based on user permission
             switch ($userPermission) {
-                // owner
+                    // owner
                 case 1:
                     return $this->syllabusEditor($syllabus, ['user' => $user, 'myCourses' => $myCourses, 'vancouverSyllabusResources' => $vancouverSyllabusResources, 'okanaganSyllabusResources' => $okanaganSyllabusResources, 'faculties' => $faculties, 'departments' => $departments, 'courseAlignment' => $courseAlignment, 'outcomeMaps' => $outcomeMaps]);
 
@@ -141,7 +141,7 @@ class SyllabusController extends Controller
                     return view('syllabus.syllabusGenerator')->with('user', $user)->with('myCourses', $myCourses)->with('inputFieldDescriptions', INPUT_TIPS)->with('okanaganSyllabusResources', $okanaganSyllabusResources)->with('vancouverSyllabusResources', $vancouverSyllabusResources)->with('faculties', $faculties)->with('departments', $departments)->with('syllabus', []);
             }
 
-        // return view to create a syllabus
+            // return view to create a syllabus
         } else {
             return view('syllabus.syllabus')->with('user', $user)->with('myCourses', $myCourses)->with('inputFieldDescriptions', INPUT_TIPS)->with('okanaganSyllabusResources', $okanaganSyllabusResources)->with('vancouverSyllabusResources', $vancouverSyllabusResources)->with('faculties', $faculties)->with('departments', $departments)->with('syllabus', []);
         }
@@ -176,9 +176,7 @@ class SyllabusController extends Controller
                 // return view with vancouver syllabus data
                 return view('syllabus.syllabus')->with('user', $data['user'])->with('myCourses', $data['myCourses'])->with('syllabusInstructors', $syllabusInstructors)->with('myCourseScheduleTbl', $courseScheduleTbl)->with('courseScheduleTblRowsCount', $courseScheduleTblRowsCount)->with('inputFieldDescriptions', INPUT_TIPS)->with('okanaganSyllabusResources', $data['okanaganSyllabusResources'])->with('vancouverSyllabusResources', $data['vancouverSyllabusResources'])->with('syllabus', $syllabus)->with('vancouverSyllabus', $vancouverSyllabus)->with('selectedVancouverSyllabusResourceIds', $selectedVancouverSyllabusResourceIds)->with('faculties', $data['faculties'])->with('departments', $data['departments'])->with('courseAlignment', $data['courseAlignment'])->with('outcomeMaps', $data['outcomeMaps']);
                 break;
-
         }
-
     }
 
     public function syllabusViewer($syllabus, $data)
@@ -238,7 +236,7 @@ class SyllabusController extends Controller
 
             // update syllabus
             $syllabus = $this->update($request, $syllabusId);
-        // else create a new syllabus
+            // else create a new syllabus
         } else {
             // create a new syllabus
 
@@ -253,7 +251,6 @@ class SyllabusController extends Controller
         // save syllabus
         if ($syllabus->save()) {
             $request->session()->flash('success', 'Your syllabus was successfully saved!');
-
         } else {
             $request->session()->flash('error', 'There was an error saving your syllabus!');
         }
@@ -307,7 +304,7 @@ class SyllabusController extends Controller
 
             // show view based on user permission
             switch ($userPermission) {
-                // owner
+                    // owner
                 case 1:
                     return $this->syllabusEditor($syllabus, ['user' => $user, 'myCourses' => $myCourses, 'vancouverSyllabusResources' => $vancouverSyllabusResources, 'okanaganSyllabusResources' => $okanaganSyllabusResources, 'faculties' => $faculties, 'departments' => $departments, 'courseAlignment' => $courseAlignment, 'outcomeMaps' => $outcomeMaps]);
 
@@ -326,7 +323,7 @@ class SyllabusController extends Controller
                     return view('syllabus.syllabusGenerator')->with('user', $user)->with('myCourses', $myCourses)->with('inputFieldDescriptions', INPUT_TIPS)->with('okanaganSyllabusResources', $okanaganSyllabusResources)->with('vancouverSyllabusResources', $vancouverSyllabusResources)->with('faculties', $faculties)->with('departments', $departments)->with('syllabus', []);
             }
 
-        // return view to create a syllabus
+            // return view to create a syllabus
         } else {
             return view('syllabus.syllabus')->with('user', $user)->with('myCourses', $myCourses)->with('inputFieldDescriptions', INPUT_TIPS)->with('okanaganSyllabusResources', $okanaganSyllabusResources)->with('vancouverSyllabusResources', $vancouverSyllabusResources)->with('faculties', $faculties)->with('departments', $departments)->with('syllabus', []);
         }
@@ -394,7 +391,7 @@ class SyllabusController extends Controller
         if ($classMeetingDays = $request->input('schedule', null)) {
             $classSchedule = '';
             foreach ($classMeetingDays as $day) {
-                $classSchedule = ($classSchedule == '' ? $day : $classSchedule.'/'.$day);
+                $classSchedule = ($classSchedule == '' ? $day : $classSchedule . '/' . $day);
             }
 
             $syllabus->class_meeting_days = $classSchedule;
@@ -630,7 +627,7 @@ class SyllabusController extends Controller
         if ($classMeetingDays = $request->input('schedule', null)) {
             $classSchedule = '';
             foreach ($classMeetingDays as $day) {
-                $classSchedule = ($classSchedule == '' ? $day : $classSchedule.'/'.$day);
+                $classSchedule = ($classSchedule == '' ? $day : $classSchedule . '/' . $day);
             }
             $syllabus->class_meeting_days = $classSchedule;
         } else {
@@ -719,7 +716,7 @@ class SyllabusController extends Controller
                         // delete all resources previously selected for the given syllabus
                         SyllabusResourceOkanagan::where('syllabus_id', $syllabus->id)->delete();
                     }
-                // campus was changed from 'V' to 'O'
+                    // campus was changed from 'V' to 'O'
                 } else {
                     // delete vancouver syllabus record
                     VancouverSyllabus::where('syllabus_id', $syllabus->id)->delete();
@@ -779,7 +776,7 @@ class SyllabusController extends Controller
                         // delete all resources previously selected for the given syllabus
                         SyllabusResourceVancouver::where('syllabus_id', $syllabus->id)->delete();
                     }
-                // campus was changed from 'O' to 'V'
+                    // campus was changed from 'O' to 'V'
                 } else {
                     // delete okanagan syllabus record
                     OkanaganSyllabus::where('syllabus_id', $syllabusId)->delete();
@@ -843,7 +840,7 @@ class SyllabusController extends Controller
             } else {
                 $request->session()->flash('error', 'There was an error deleting your syllabus');
             }
-        // else the current user does not own the syllabus, flash an error
+            // else the current user does not own the syllabus, flash an error
         } else {
             $request->session()->flash('error', 'You do not have permission to delete this syllabus');
         }
@@ -870,7 +867,6 @@ class SyllabusController extends Controller
                 foreach ($outcomeMaps as $outcomeMap) {
                     $programsOutcomeMaps[$programId]['outcomeMap'][$programLearningOutcome->pl_outcome_id][$outcomeMap->l_outcome_id] = MappingScale::find($outcomeMap->pivot->map_scale_id);
                 }
-
             }
         }
 
@@ -1000,22 +996,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($CDArr as $index => $courseDesc) {
                             $templateProcessor->cloneBlock('NocourseDescription');
-                            $templateProcessor->setValue('courseDescriptionOK'.$i, $courseDesc.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('courseDescriptionOK' . $i, $courseDesc . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseDescriptionOK'.$i, '');
+                            $templateProcessor->setValue('courseDescriptionOK' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NocourseDescription');
                         $templateProcessor->setValue('courseDescriptionOK0', str_replace("\n", '</w:t><w:br/><w:t>', $okanaganSyllabus->course_description));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseDescriptionOK'.$i, '');
+                            $templateProcessor->setValue('courseDescriptionOK' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NocourseDescription', 0);
                 }
@@ -1028,22 +1023,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($CFArr as $index => $courseForm) {
                             $templateProcessor->cloneBlock('NocourseFormat');
-                            $templateProcessor->setValue('courseFormat'.$i, $courseForm.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('courseFormat' . $i, $courseForm . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseFormat'.$i, '');
+                            $templateProcessor->setValue('courseFormat' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NocourseFormat');
                         $templateProcessor->setValue('courseFormat0', str_replace("\n", '</w:t><w:br/><w:t>', $okanaganSyllabus->course_format));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseFormat'.$i, '');
+                            $templateProcessor->setValue('courseFormat' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NocourseFormat', 0);
                 }
@@ -1056,22 +1050,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($COArr as $index => $courseOver) {
                             $templateProcessor->cloneBlock('NocourseOverview');
-                            $templateProcessor->setValue('courseOverview'.$i, $courseOver.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('courseOverview' . $i, $courseOver . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 30; $i++) {
-                            $templateProcessor->setValue('courseOverview'.$i, '');
+                            $templateProcessor->setValue('courseOverview' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NocourseOverview');
                         $templateProcessor->setValue('courseOverview0', str_replace("\n", '</w:t><w:br/><w:t>', $okanaganSyllabus->course_overview));
                         $i++;
                         for ($i; $i <= 30; $i++) {
-                            $templateProcessor->setValue('courseOverview'.$i, '');
+                            $templateProcessor->setValue('courseOverview' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NocourseOverview', 0);
                 }
@@ -1106,76 +1099,67 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($LearnActArr as $index => $learnAct) {
                             $templateProcessor->cloneBlock('NoLearningActivities');
-                            $templateProcessor->setValue('learningActivities'.$i, $learnAct.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('learningActivities' . $i, $learnAct . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningActivities'.$i, '');
+                            $templateProcessor->setValue('learningActivities' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoLearningActivities');
                         $templateProcessor->setValue('learningActivities0', str_replace("\n", '</w:t><w:br/><w:t>', $syllabus->learning_activities));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningActivities'.$i, '');
+                            $templateProcessor->setValue('learningActivities' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoLearningActivities', 0);
                 }
 
-                
+
                 // tell template processor to include prerequisites if user completed the field(s)
-                if ($syllabus->prerequisites) {
-                    $prerequisitesArr = explode("\n", $syllabus->prerequisites);
-                    $i = 0;
-                    if ($ext == 'pdf') {
-                        foreach ($prerequisitesArr as $index => $prereqs) {
-                            $templateProcessor->cloneBlock('NoPrerequisites');
-                            $templateProcessor->setValue('prerequisites'.$i, $prereqs.'</w:t><w:br/><w:t>');
-                            $i++;
-                        }
-
-                        for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('prerequisites'.$i, '');
-                        }
-                    } else {
-                        $templateProcessor->cloneBlock('NoPrerequisites');
-                        $templateProcessor->setValue('prerequisites0', str_replace("\n", '</w:t><w:br/><w:t>', $syllabus->prerequisites));
-                        $i++;
-                        for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('prerequisites'.$i, '');
-                        }
+                if ($coursePrereqs = $syllabus->prerequisites) {
+                    $templateProcessor->cloneBlock('NoPrerequisites');
+                    // split course prereqs string on newline char and comma
+                    $coursePrereqsArr = preg_split('/[,\n]+/', $coursePrereqs);
+                    // clean up whitespace from each item
+                    $coursePrereqsArr = array_map('trim', $coursePrereqsArr);
+                    // remove any empty entries
+                    $coursePrereqsArr = array_filter($coursePrereqsArr);
+                    // create a table for course prereqs (workaround for no list option)
+                    $coursePrereqsTable = new Table($tableStyle);
+                    // add a new row and cell to table for each prereq
+                    foreach ($coursePrereqsArr as $index => $prereq) {
+                        $coursePrereqsTable->addRow();
+                        $coursePrereqsTable->addCell()->addText(strval($index + 1));
+                        $coursePrereqsTable->addCell()->addText($prereq);
                     }
-
+                    // add course prereqs table to word doc
+                    $templateProcessor->setComplexBlock('prerequisites0', $coursePrereqsTable);
                 } else {
                     $templateProcessor->cloneBlock('NoPrerequisites', 0);
                 }
-                // tell template processor to include corequisites if user completed the field(s)
-                if ($syllabus->corequisites) {
-                    $corequisitesArr = explode("\n", $syllabus->corequisites);
-                    $i = 0;
-                    if ($ext == 'pdf') {
-                        foreach ($corequisitesArr as $index => $coreqs) {
-                            $templateProcessor->cloneBlock('NoCorequisites');
-                            $templateProcessor->setValue('corequisites'.$i, $coreqs.'</w:t><w:br/><w:t>');
-                            $i++;
-                        }
 
-                        for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('corequisites'.$i, '');
-                        }
-                    } else {
-                        $templateProcessor->cloneBlock('NoCorequisites');
-                        $templateProcessor->setValue('corequisites0', str_replace("\n", '</w:t><w:br/><w:t>', $syllabus->corequisites));
-                        $i++;
-                        for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('corequisites'.$i, '');
-                        }
+                if ($courseCoreqs = $syllabus->corequisites) {
+                    $templateProcessor->cloneBlock('NoCorequisites');
+                    // split course coreqs string on newline char and comma
+                    $courseCoreqsArr = preg_split('/[,\n]+/', $courseCoreqs);
+                    // clean up whitespace from each item
+                    $courseCoreqsArr = array_map('trim', $courseCoreqsArr);
+                    // remove any empty entries
+                    $courseCoreqsArr = array_filter($courseCoreqsArr);
+                    // create a table for course coreqs (workaround for no list option)
+                    $courseCoreqsTable = new Table($tableStyle);
+                    // add a new row and cell to table for each coreq
+                    foreach ($courseCoreqsArr as $index => $coreq) {
+                        $courseCoreqsTable->addRow();
+                        $courseCoreqsTable->addCell()->addText(strval($index + 1));
+                        $courseCoreqsTable->addCell()->addText($coreq);
                     }
-
+                    // add course coreqs table to word doc
+                    $templateProcessor->setComplexBlock('corequisites0', $courseCoreqsTable);
                 } else {
                     $templateProcessor->cloneBlock('NoCorequisites', 0);
                 }
@@ -1186,22 +1170,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($otherCourseStaffArr as $index => $otherCourseStaff) {
                             $templateProcessor->cloneBlock('NoOtherInstructionalStaff');
-                            $templateProcessor->setValue('otherInstructionalStaff'.$i, $otherCourseStaff.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('otherInstructionalStaff' . $i, $otherCourseStaff . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('otherInstructionalStaff'.$i, '');
+                            $templateProcessor->setValue('otherInstructionalStaff' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoOtherInstructionalStaff');
                         $templateProcessor->setValue('otherInstructionalStaff0', str_replace("\n", '</w:t><w:br/><w:t>', $syllabus->other_instructional_staff));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('otherInstructionalStaff'.$i, '');
+                            $templateProcessor->setValue('otherInstructionalStaff' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoOtherInstructionalStaff', 0);
                 }
@@ -1284,22 +1267,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($LOutArr as $index => $courseLOut) {
                             $templateProcessor->cloneBlock('NolearningOutcomes');
-                            $templateProcessor->setValue('learningOutcomes'.$i, $courseLOut.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('learningOutcomes' . $i, $courseLOut . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningOutcomes'.$i, '');
+                            $templateProcessor->setValue('learningOutcomes' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NolearningOutcomes');
                         $templateProcessor->setValue('learningOutcomes0', str_replace("\n", '</w:t><w:br/><w:t>', $syllabus->learning_outcomes));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningOutcomes'.$i, '');
+                            $templateProcessor->setValue('learningOutcomes' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NolearningOutcomes', 0);
                 }
@@ -1310,22 +1292,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($LAssArr as $index => $courseLAss) {
                             $templateProcessor->cloneBlock('NolearningAssessments');
-                            $templateProcessor->setValue('learningAssessments'.$i, $courseLAss.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('learningAssessments' . $i, $courseLAss . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningAssessments'.$i, '');
+                            $templateProcessor->setValue('learningAssessments' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NolearningAssessments');
                         $templateProcessor->setValue('learningAssessments0', str_replace("\n", '</w:t><w:br/><w:t>', $syllabus->learning_assessments));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningAssessments'.$i, '');
+                            $templateProcessor->setValue('learningAssessments' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NolearningAssessments', 0);
                 }
@@ -1338,22 +1319,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($LRArr as $index => $courseLR) {
                             $templateProcessor->cloneBlock('NocourseLearningResources');
-                            $templateProcessor->setValue('courseLearningResources'.$i, $courseLR.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('courseLearningResources' . $i, $courseLR . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseLearningResources'.$i, '');
+                            $templateProcessor->setValue('courseLearningResources' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NocourseLearningResources');
                         $templateProcessor->setValue('courseLearningResources0', str_replace("\n", '</w:t><w:br/><w:t>', $syllabus->learning_resources));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseLearningResources'.$i, '');
+                            $templateProcessor->setValue('courseLearningResources' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NocourseLearningResources', 0);
                 }
@@ -1366,22 +1346,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($LMArr as $index => $courseLM) {
                             $templateProcessor->cloneBlock('NoLearningMaterials');
-                            $templateProcessor->setValue('learningMaterials'.$i, $courseLM.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('learningMaterials' . $i, $courseLM . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningMaterials'.$i, '');
+                            $templateProcessor->setValue('learningMaterials' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoLearningMaterials');
                         $templateProcessor->setValue('learningMaterials0', str_replace("\n", '</w:t><w:br/><w:t>', $learningMaterials));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningMaterials'.$i, '');
+                            $templateProcessor->setValue('learningMaterials' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoLearningMaterials', 0);
                 }
@@ -1392,8 +1371,8 @@ class SyllabusController extends Controller
                 foreach ($allOkanaganSyllabusResources as $resource) {
                     if (in_array($resource->id, $selectedOkanaganSyllabusResourceIds)) {
                         $templateProcessor->cloneBlock($resource->id_name);
-                        $templateProcessor->setValue($resource->id_name.'-title', $resource->title);
-                    // $templateProcessor->setValue($resource->id_name . '-description', $resource->description);
+                        $templateProcessor->setValue($resource->id_name . '-title', $resource->title);
+                        // $templateProcessor->setValue($resource->id_name . '-description', $resource->description);
                     } else {
                         $templateProcessor->cloneBlock($resource->id_name, 0);
                     }
@@ -1421,22 +1400,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($CDVArr as $index => $courseCDV) {
                             $templateProcessor->cloneBlock('NoCourseDescription');
-                            $templateProcessor->setValue('courseDescription'.$i, $courseCDV.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('courseDescription' . $i, $courseCDV . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseDescription'.$i, '');
+                            $templateProcessor->setValue('courseDescription' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoCourseDescription');
                         $templateProcessor->setValue('courseDescription0', str_replace("\n", '</w:t><w:br/><w:t>', $courseDescription));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseDescription'.$i, '');
+                            $templateProcessor->setValue('courseDescription' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoCourseDescription', 0);
                 }
@@ -1457,7 +1435,6 @@ class SyllabusController extends Controller
                     }
                     // add contacts table to word doc
                     $templateProcessor->setComplexBlock('contacts', $contactsTable);
-
                 } else {
                     $templateProcessor->cloneBlock('NoContacts');
                     $templateProcessor->setValue('contacts', '');
@@ -1513,22 +1490,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($CIBArr as $index => $courseCIB) {
                             $templateProcessor->cloneBlock('NoInstructorBio');
-                            $templateProcessor->setValue('instructorBio'.$i, $courseCIB.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('instructorBio' . $i, $courseCIB . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('instructorBio'.$i, '');
+                            $templateProcessor->setValue('instructorBio' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoInstructorBio');
                         $templateProcessor->setValue('instructorBio0', str_replace("\n", '</w:t><w:br/><w:t>', $courseInstructorBio));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('instructorBio'.$i, '');
+                            $templateProcessor->setValue('instructorBio' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoInstructorBio', 0);
                 }
@@ -1542,12 +1518,12 @@ class SyllabusController extends Controller
                         foreach ($CStructArr as $index => $courseStruct) {
                             $templateProcessor->cloneBlock('NoCourseStructureDesc', 0);
                             $templateProcessor->cloneBlock('NoCourseStructure');
-                            $templateProcessor->setValue('courseStructure'.$i, $courseStruct.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('courseStructure' . $i, $courseStruct . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseStructure'.$i, '');
+                            $templateProcessor->setValue('courseStructure' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoCourseStructureDesc', 0);
@@ -1555,10 +1531,9 @@ class SyllabusController extends Controller
                         $templateProcessor->setValue('courseStructure0', str_replace("\n", '</w:t><w:br/><w:t>', $courseStructure));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseStructure'.$i, '');
+                            $templateProcessor->setValue('courseStructure' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoCourseStructureDesc');
                     $templateProcessor->cloneBlock('NoCourseStructure', 0);
@@ -1577,12 +1552,12 @@ class SyllabusController extends Controller
                         foreach ($LearnActArr as $index => $learnAct) {
                             $templateProcessor->cloneBlock('NoLearningActivities');
                             $templateProcessor->cloneBlock('NoLearningActivitiesDesc', 0);
-                            $templateProcessor->setValue('learningActivities'.$i, $learnAct.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('learningActivities' . $i, $learnAct . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningActivities'.$i, '');
+                            $templateProcessor->setValue('learningActivities' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoLearningActivities');
@@ -1590,10 +1565,9 @@ class SyllabusController extends Controller
                         $templateProcessor->setValue('learningActivities0', str_replace("\n", '</w:t><w:br/><w:t>', $learningActivities));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningActivities'.$i, '');
+                            $templateProcessor->setValue('learningActivities' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoLearningActivities', 0);
                     $templateProcessor->cloneBlock('NoLearningActivitiesDesc');
@@ -1606,22 +1580,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($otherCourseStaffArr as $index => $otherCourseStaff) {
                             $templateProcessor->cloneBlock('NoOtherInstructionalStaff');
-                            $templateProcessor->setValue('otherInstructionalStaff'.$i, $otherCourseStaff.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('otherInstructionalStaff' . $i, $otherCourseStaff . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('otherInstructionalStaff'.$i, '');
+                            $templateProcessor->setValue('otherInstructionalStaff' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoOtherInstructionalStaff');
                         $templateProcessor->setValue('otherInstructionalStaff0', str_replace("\n", '</w:t><w:br/><w:t>', $syllabus->other_instructional_staff));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('otherInstructionalStaff'.$i, '');
+                            $templateProcessor->setValue('otherInstructionalStaff' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoOtherInstructionalStaff', 0);
                 }
@@ -1686,12 +1659,12 @@ class SyllabusController extends Controller
                         foreach ($LOutArr as $index => $courseLOut) {
                             $templateProcessor->cloneBlock('NolearningOutcomesDesc', 0);
                             $templateProcessor->cloneBlock('NolearningOutcomes');
-                            $templateProcessor->setValue('learningOutcomes'.$i, $courseLOut.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('learningOutcomes' . $i, $courseLOut . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningOutcomes'.$i, '');
+                            $templateProcessor->setValue('learningOutcomes' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NolearningOutcomesDesc', 0);
@@ -1699,10 +1672,9 @@ class SyllabusController extends Controller
                         $templateProcessor->setValue('learningOutcomes0', str_replace("\n", '</w:t><w:br/><w:t>', $learningOutcome));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningOutcomes'.$i, '');
+                            $templateProcessor->setValue('learningOutcomes' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NolearningOutcomesDesc');
                     $templateProcessor->cloneBlock('NolearningOutcomes', 0);
@@ -1715,12 +1687,12 @@ class SyllabusController extends Controller
                         foreach ($LAssArr as $index => $courseLAss) {
                             $templateProcessor->cloneBlock('NolearningAssessmentsDesc', 0);
                             $templateProcessor->cloneBlock('NolearningAssessments');
-                            $templateProcessor->setValue('learningAssessments'.$i, $courseLAss.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('learningAssessments' . $i, $courseLAss . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningAssessments'.$i, '');
+                            $templateProcessor->setValue('learningAssessments' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NolearningAssessmentsDesc', 0);
@@ -1728,10 +1700,9 @@ class SyllabusController extends Controller
                         $templateProcessor->setValue('learningAssessments0', str_replace("\n", '</w:t><w:br/><w:t>', $learningAssessments));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningAssessments'.$i, '');
+                            $templateProcessor->setValue('learningAssessments' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NolearningAssessmentsDesc');
                     $templateProcessor->cloneBlock('NolearningAssessments', 0);
@@ -1744,22 +1715,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($LRVArr as $index => $courseLRV) {
                             $templateProcessor->cloneBlock('NoCourseLearningResources');
-                            $templateProcessor->setValue('courseLearningResources'.$i, $courseLRV.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('courseLearningResources' . $i, $courseLRV . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseLearningResources'.$i, '');
+                            $templateProcessor->setValue('courseLearningResources' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoCourseLearningResources');
                         $templateProcessor->setValue('courseLearningResources0', str_replace("\n", '</w:t><w:br/><w:t>', $learningResources));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('courseLearningResources'.$i, '');
+                            $templateProcessor->setValue('courseLearningResources' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoCourseLearningResources', 0);
                 }
@@ -1773,12 +1743,12 @@ class SyllabusController extends Controller
                         foreach ($LMVArr as $index => $courseLMV) {
                             $templateProcessor->cloneBlock('NoLearningMaterials');
                             $templateProcessor->cloneBlock('NoLearningMaterialsDesc', 0);
-                            $templateProcessor->setValue('learningMaterials'.$i, $courseLMV.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('learningMaterials' . $i, $courseLMV . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningMaterials'.$i, '');
+                            $templateProcessor->setValue('learningMaterials' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoLearningMaterials');
@@ -1786,10 +1756,9 @@ class SyllabusController extends Controller
                         $templateProcessor->setValue('learningMaterials0', str_replace("\n", '</w:t><w:br/><w:t>', $learningMaterials));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningMaterials'.$i, '');
+                            $templateProcessor->setValue('learningMaterials' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoLearningMaterials', 0);
                     $templateProcessor->cloneBlock('NoLearningMaterialsDesc');
@@ -1805,22 +1774,21 @@ class SyllabusController extends Controller
                     if ($ext == 'pdf') {
                         foreach ($LAVArr as $index => $courseLAV) {
                             $templateProcessor->cloneBlock('NoLearningAnalytics');
-                            $templateProcessor->setValue('learningAnalytics'.$i, $courseLAV.'</w:t><w:br/><w:t>');
+                            $templateProcessor->setValue('learningAnalytics' . $i, $courseLAV . '</w:t><w:br/><w:t>');
                             $i++;
                         }
 
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningAnalytics'.$i, '');
+                            $templateProcessor->setValue('learningAnalytics' . $i, '');
                         }
                     } else {
                         $templateProcessor->cloneBlock('NoLearningAnalytics');
                         $templateProcessor->setValue('learningAnalytics0', str_replace("\n", '</w:t><w:br/><w:t>', $learningAnalytics));
                         $i++;
                         for ($i; $i <= 20; $i++) {
-                            $templateProcessor->setValue('learningAnalytics'.$i, '');
+                            $templateProcessor->setValue('learningAnalytics' . $i, '');
                         }
                     }
-
                 } else {
                     $templateProcessor->cloneBlock('NoLearningAnalytics', 0);
                 }
@@ -1831,8 +1799,8 @@ class SyllabusController extends Controller
                 foreach ($allVancouverSyllabusResources as $resource) {
                     if (in_array($resource->id, $selectedVancouverSyllabusResourceIds)) {
                         $templateProcessor->cloneBlock($resource->id_name);
-                        $templateProcessor->setValue($resource->id_name.'-title', strtoupper($resource->title));
-                    // $templateProcessor->setValue($resource->id_name . '-description', $resource->description);
+                        $templateProcessor->setValue($resource->id_name . '-title', strtoupper($resource->title));
+                        // $templateProcessor->setValue($resource->id_name . '-description', $resource->description);
                     } else {
                         $templateProcessor->cloneBlock($resource->id_name, 0);
                     }
@@ -1848,24 +1816,22 @@ class SyllabusController extends Controller
             if ($ext == 'pdf') {
                 foreach ($CRArr as $index => $courseCR) {
                     $templateProcessor->cloneBlock('NoCustomResource');
-                    $templateProcessor->setValue('custom_resource'.$i, $courseCR.'</w:t><w:br/><w:t>');
+                    $templateProcessor->setValue('custom_resource' . $i, $courseCR . '</w:t><w:br/><w:t>');
                     $i++;
                 }
 
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('custom_resource'.$i, '');
+                    $templateProcessor->setValue('custom_resource' . $i, '');
                 }
-
             } else {
                 $templateProcessor->cloneBlock('NoCustomResource');
                 $templateProcessor->setValue('custom_resource0', str_replace("\n", '</w:t><w:br/><w:t>', $syllabus->custom_resource));
                 $i++;
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('custom_resource'.$i, '');
+                    $templateProcessor->setValue('custom_resource' . $i, '');
                 }
             }
             $templateProcessor->setValue('custom_resource_title', $syllabus->custom_resource_title);
-
         } else {
             $templateProcessor->cloneBlock('NoCustomResource', 0);
         }
@@ -1894,9 +1860,9 @@ class SyllabusController extends Controller
             $templateProcessor->cloneBlock('NoLand', 0);
         }
 
-        $courseName = ($syllabus->course_code).' '.($syllabus->course_num);
+        $courseName = ($syllabus->course_code) . ' ' . ($syllabus->course_num);
         if ($syllabus->cross_listed_code != null) {
-            $courseName = $courseName.'/'.($syllabus->cross_listed_code).' '.($syllabus->cross_listed_num);
+            $courseName = $courseName . '/' . ($syllabus->cross_listed_code) . ' ' . ($syllabus->cross_listed_num);
         }
 
         // add required form fields common to both campuses to template
@@ -1907,13 +1873,13 @@ class SyllabusController extends Controller
         $templateProcessor->setValue('courseInstructorEmail', $syllabusInstructors->implode('email', ', '));
 
         switch ($syllabus->delivery_modality) {
-            case 'M' :
+            case 'M':
                 $templateProcessor->setValue('deliveryModality', 'Multi-Access');
                 break;
-            case 'I' :
+            case 'I':
                 $templateProcessor->setValue('deliveryModality', 'In-Person');
                 break;
-            case 'B' :
+            case 'B':
                 $templateProcessor->setValue('deliveryModality', 'Hybrid');
                 break;
             default:
@@ -1952,22 +1918,21 @@ class SyllabusController extends Controller
             if ($ext == 'pdf') {
                 foreach ($LPArr as $index => $courseLP) {
                     $templateProcessor->cloneBlock('NolatePolicy');
-                    $templateProcessor->setValue('latePolicy'.$i, $courseLP.'</w:t><w:br/><w:t>');
+                    $templateProcessor->setValue('latePolicy' . $i, $courseLP . '</w:t><w:br/><w:t>');
                     $i++;
                 }
 
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('latePolicy'.$i, '');
+                    $templateProcessor->setValue('latePolicy' . $i, '');
                 }
             } else {
                 $templateProcessor->cloneBlock('NolatePolicy');
                 $templateProcessor->setValue('latePolicy0', str_replace("\n", '</w:t><w:br/><w:t>', $latePolicy));
                 $i++;
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('latePolicy'.$i, '');
+                    $templateProcessor->setValue('latePolicy' . $i, '');
                 }
             }
-
         } else {
             $templateProcessor->cloneBlock('NolatePolicy', 0);
         }
@@ -1980,22 +1945,21 @@ class SyllabusController extends Controller
             if ($ext == 'pdf') {
                 foreach ($MEArr as $index => $courseME) {
                     $templateProcessor->cloneBlock('NoMissingExam');
-                    $templateProcessor->setValue('missingExam'.$i, $courseME.'</w:t><w:br/><w:t>');
+                    $templateProcessor->setValue('missingExam' . $i, $courseME . '</w:t><w:br/><w:t>');
                     $i++;
                 }
 
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('missingExam'.$i, '');
+                    $templateProcessor->setValue('missingExam' . $i, '');
                 }
             } else {
                 $templateProcessor->cloneBlock('NoMissingExam');
                 $templateProcessor->setValue('missingExam0', str_replace("\n", '</w:t><w:br/><w:t>', $missingExam));
                 $i++;
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('missingExam'.$i, '');
+                    $templateProcessor->setValue('missingExam' . $i, '');
                 }
             }
-
         } else {
             $templateProcessor->cloneBlock('NoMissingExam', 0);
         }
@@ -2008,22 +1972,21 @@ class SyllabusController extends Controller
             if ($ext == 'pdf') {
                 foreach ($MAArr as $index => $courseMA) {
                     $templateProcessor->cloneBlock('NomissingActivity');
-                    $templateProcessor->setValue('missingActivity'.$i, $courseMA.'</w:t><w:br/><w:t>');
+                    $templateProcessor->setValue('missingActivity' . $i, $courseMA . '</w:t><w:br/><w:t>');
                     $i++;
                 }
 
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('missingActivity'.$i, '');
+                    $templateProcessor->setValue('missingActivity' . $i, '');
                 }
             } else {
                 $templateProcessor->cloneBlock('NomissingActivity');
                 $templateProcessor->setValue('missingActivity0', str_replace("\n", '</w:t><w:br/><w:t>', $missingActivity));
                 $i++;
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('missingActivity'.$i, '');
+                    $templateProcessor->setValue('missingActivity' . $i, '');
                 }
             }
-
         } else {
             $templateProcessor->cloneBlock('NomissingActivity', 0);
         }
@@ -2036,22 +1999,21 @@ class SyllabusController extends Controller
             if ($ext == 'pdf') {
                 foreach ($PCArr as $index => $coursePC) {
                     $templateProcessor->cloneBlock('NopassingCriteria');
-                    $templateProcessor->setValue('passingCriteria'.$i, $coursePC.'</w:t><w:br/><w:t>');
+                    $templateProcessor->setValue('passingCriteria' . $i, $coursePC . '</w:t><w:br/><w:t>');
                     $i++;
                 }
 
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('passingCriteria'.$i, '');
+                    $templateProcessor->setValue('passingCriteria' . $i, '');
                 }
             } else {
                 $templateProcessor->cloneBlock('NopassingCriteria');
                 $templateProcessor->setValue('passingCriteria0', str_replace("\n", '</w:t><w:br/><w:t>', $passingCriteria));
                 $i++;
                 for ($i; $i <= 20; $i++) {
-                    $templateProcessor->setValue('passingCriteria'.$i, '');
+                    $templateProcessor->setValue('passingCriteria' . $i, '');
                 }
             }
-
         } else {
             $templateProcessor->cloneBlock('NopassingCriteria', 0);
         }
@@ -2082,7 +2044,6 @@ class SyllabusController extends Controller
             }
             // add course schedule table to word doc
             $templateProcessor->setComplexBlock('courseScheduleTbl', $courseScheduleTable);
-
         } else {
             $templateProcessor->cloneBlock('NoTopicsSchedule');
             $templateProcessor->cloneBlock('NoCourseScheduleTbl', 0);
@@ -2112,29 +2073,28 @@ class SyllabusController extends Controller
         // word file ext
         $wordFileExt = '.docx';
         // save word document on server
-        $templateProcessor->saveAs($fileName.$wordFileExt);
+        $templateProcessor->saveAs($fileName . $wordFileExt);
 
         if ($ext == 'pdf') {
             // pdf file ext
             $pdfFileExt = '.pdf';
-            $pdfRendererPath = base_path(DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'dompdf'.DIRECTORY_SEPARATOR.'dompdf');
+            $pdfRendererPath = base_path(DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'dompdf' . DIRECTORY_SEPARATOR . 'dompdf');
             Settings::setPdfRendererPath($pdfRendererPath);
             Settings::setPdfRendererName('DomPDF');
             // get path to word file
-            $wordFilePath = config('app.env') == 'local' ? public_path($fileName.$wordFileExt) : base_path('html'.DIRECTORY_SEPARATOR.$fileName.$wordFileExt);
+            $wordFilePath = config('app.env') == 'local' ? public_path($fileName . $wordFileExt) : base_path('html' . DIRECTORY_SEPARATOR . $fileName . $wordFileExt);
             // load word file
             $wordFileContent = IOFactory::load($wordFilePath);
             $pdfWriter = IOFactory::createWriter($wordFileContent, 'PDF');
-            $pdfWriter->save($fileName.$pdfFileExt);
+            $pdfWriter->save($fileName . $pdfFileExt);
             // delete the word version
-            unlink($fileName.$wordFileExt);
+            unlink($fileName . $wordFileExt);
 
             // return pdf download response
-            return response()->download($fileName.$pdfFileExt)->deleteFileAfterSend(true);
-
+            return response()->download($fileName . $pdfFileExt)->deleteFileAfterSend(true);
         }
 
-        return response()->download($fileName.$wordFileExt)->deleteFileAfterSend(true);
+        return response()->download($fileName . $wordFileExt)->deleteFileAfterSend(true);
     }
 
     private function addAlignmentToWordDoc($syllabusId, $docTemplate, $styles)
@@ -2152,8 +2112,8 @@ class SyllabusController extends Controller
         // add a new row and cell to table for each learning outcome and its alignment
         foreach ($importCourse->learningOutcomes as $rowIndex => $clo) {
             $courseAlignmentTable->addRow();
-            isset($clo->clo_shortphrase) ? $shortphrase = $clo->clo_shortphrase.': ' : $shortphrase = '';
-            $courseAlignmentTable->addCell()->addText($shortphrase.$clo->l_outcome);
+            isset($clo->clo_shortphrase) ? $shortphrase = $clo->clo_shortphrase . ': ' : $shortphrase = '';
+            $courseAlignmentTable->addCell()->addText($shortphrase . $clo->l_outcome);
             $courseAlignmentTable->addCell()->addText($clo->assessmentMethods->implode('a_method', ', '));
             $courseAlignmentTable->addCell()->addText($clo->learningActivities->implode('l_activity', ', '));
         }
@@ -2171,19 +2131,19 @@ class SyllabusController extends Controller
             if ($index > 4) {
                 break;
             }
-            $docTemplate->setValue('programtitle-'.strval($index), strtoupper($outcomeMap['program']->program));
+            $docTemplate->setValue('programtitle-' . strval($index), strtoupper($outcomeMap['program']->program));
             $this->addMappingScaleTblToWordDoc($outcomeMap['program']->mappingScaleLevels, $docTemplate, $index, $styles);
             if (isset($outcomeMap['outcomeMap'])) {
                 $this->addOutcomeMapTblToWordDoc($outcomeMap['program'], $course->learningOutcomes, $outcomeMap['outcomeMap'], $docTemplate, $index, $styles);
             } else {
-                $docTemplate->setValue('outcomeMap-'.strval($index), '');
+                $docTemplate->setValue('outcomeMap-' . strval($index), '');
             }
         }
         // remove remaining template tags in word doc
         while ($index < 5) {
-            $docTemplate->setValue('programtitle-'.strval($index), '');
-            $docTemplate->setValue('mappingScale-'.strval($index), '');
-            $docTemplate->setValue('outcomeMap-'.strval($index), '');
+            $docTemplate->setValue('programtitle-' . strval($index), '');
+            $docTemplate->setValue('mappingScale-' . strval($index), '');
+            $docTemplate->setValue('outcomeMap-' . strval($index), '');
             $index++;
         }
     }
@@ -2202,11 +2162,11 @@ class SyllabusController extends Controller
         foreach ($mappingScales as $mappingScaleLevel) {
             $mappingScalesTbl->addRow();
             $mappingScalesTbl->addCell(null, ['bgColor' => substr($mappingScaleLevel->colour, 1)]);
-            $mappingScalesTbl->addCell()->addText($mappingScaleLevel->title.' ('.$mappingScaleLevel->abbreviation.')');
+            $mappingScalesTbl->addCell()->addText($mappingScaleLevel->title . ' (' . $mappingScaleLevel->abbreviation . ')');
             $mappingScalesTbl->addCell()->addText($mappingScaleLevel->description);
             ['bgColor' => 'c6e0f5', 'borderBottomColor' => '000000'];
         }
-        $docTemplate->setComplexBlock('mappingScale-'.strval($index), $mappingScalesTbl);
+        $docTemplate->setComplexBlock('mappingScale-' . strval($index), $mappingScalesTbl);
     }
 
     private function addOutcomeMapTblToWordDoc($program, $clos, $outcomeMap, $docTemplate, $index, $styles)
@@ -2296,7 +2256,7 @@ class SyllabusController extends Controller
                 }
             }
         }
-        $docTemplate->setComplexBlock('outcomeMap-'.strval($index), $outcomeMapTbl);
+        $docTemplate->setComplexBlock('outcomeMap-' . strval($index), $outcomeMapTbl);
     }
 
     public function duplicate(Request $request, $syllabusId): RedirectResponse

--- a/resources/views/syllabus/syllabus.blade.php
+++ b/resources/views/syllabus/syllabus.blade.php
@@ -354,42 +354,42 @@
 
         <div class="col-6">
             <label for="prerequisites">Prerequisites</label><span class="requiredBySenateOK"></span>
-            <div id="formatPrereqs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+            <div id="formatPrereqs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden; transition:height 0.3s ease-out; height:auto; font-size:0.5rem;">
                 <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i>
-                <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+                <span style="font-size:0.80rem;">Place each entry on a new line for the best formatting results.</span>
             </div>
             <textarea
                 data-formatnoteid="formatPrereqs"
-                oninput="validateMaxlength()"
+                oninput="autoResize(this)"
                 onpaste="validateMaxlength()"
                 maxlength="7500"
                 id="prerequisites"
                 name="prerequisites"
                 class="form-control"
-                style="height:125px;"
-                type="text"
+                style="min-height:38px; max-height:200px; resize:none; overflow-y:hidden;"
+                rows="1"
                 form="sylabusGenerator"
-                placeholder="E.g. COSC 111 or COSC 123&#10;MATH 221&#10;PSYO 111"
+                placeholder="E.g. COSC 111 or COSC 123"
                 spellcheck="true">{{ !empty($syllabus) ? $syllabus->prerequisites : ''}}</textarea>
         </div>
         <div class="col-6">
             <label for="corequisites">Corequisites</label><span class="requiredBySenateOK"></span>
-            <div id="formatCoreqs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+            <div id="formatCoreqs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden; transition:height 0.3s ease-out; height:auto; font-size:0.5rem;">
                 <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i>
-                <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+                <span style="font-size:0.80rem;">Place each entry on a new line for the best formatting results.</span>
             </div>
             <textarea
                 data-formatnoteid="formatCoreqs"
-                oninput="validateMaxlength()"
+                oninput="autoResize(this)"
                 onpaste="validateMaxlength()"
                 maxlength="7500"
                 id="corequisites"
                 name="corequisites"
                 class="form-control"
-                style="height:125px;"
-                type="text"
+                style="min-height:38px; max-height:200px; resize:none; overflow-y:hidden;"
+                rows="1"
                 form="sylabusGenerator"
-                placeholder="E.g. COSC 111&#10;COSC 123"
+                placeholder="E.g. COSC 111"
                 spellcheck="true">{{ !empty($syllabus) ? $syllabus->corequisites : ''}}</textarea>
         </div>
 
@@ -1291,6 +1291,12 @@
     });
     var departments = <?php echo json_encode($departments); ?>;
 
+    function autoResize(textarea) {
+        validateMaxlength();
+        textarea.style.height = 'auto';
+        textarea.style.height = (textarea.scrollHeight) + 'px';
+    }
+
     $(document).ready(function() {
 
         $(function() {
@@ -1467,6 +1473,39 @@
                                  `);
 
             $('#copyrightEx').html(``);
+
+            // Initialize textareas
+            ['prerequisites', 'corequisites'].forEach(id => {
+                const textarea = document.getElementById(id);
+                if (textarea) {
+                    textarea.addEventListener('input', function() {
+                        autoResize(this);
+                    });
+
+                    // Initial resize if there's content
+                    if (textarea.value) {
+                        autoResize(textarea);
+                    }
+                }
+            });
+
+
+            // If campus is already selected (viewing existing syllabus)
+            if ($('#campus').val()) {
+                const prereqsTextarea = document.getElementById('prerequisites');
+                const coreqsTextarea = document.getElementById('corequisites');
+
+                setTimeout(() => {
+                    if (prereqsTextarea && prereqsTextarea.value) {
+                        prereqsTextarea.style.height = 'auto';
+                        prereqsTextarea.style.height = prereqsTextarea.scrollHeight + 'px';
+                    }
+                    if (coreqsTextarea && coreqsTextarea.value) {
+                        coreqsTextarea.style.height = 'auto';
+                        coreqsTextarea.style.height = coreqsTextarea.scrollHeight + 'px';
+                    }
+                }, 100);
+            }
 
         });
 
@@ -2799,6 +2838,23 @@
             // Show prerequisites and corequisites inputs for Okanagan
             $('#prerequisites').closest('.col-6').show();
             $('#corequisites').closest('.col-6').show();
+
+            // Force resize of textareas if they contain content
+            if (syllabus && syllabus.prerequisites) {
+                const prereqsTextarea = document.getElementById('prerequisites');
+                if (prereqsTextarea) {
+                    prereqsTextarea.style.height = 'auto';
+                    prereqsTextarea.style.height = prereqsTextarea.scrollHeight + 'px';
+                }
+            }
+
+            if (syllabus && syllabus.corequisites) {
+                const coreqsTextarea = document.getElementById('corequisites');
+                if (coreqsTextarea) {
+                    coreqsTextarea.style.height = 'auto';
+                    coreqsTextarea.style.height = coreqsTextarea.scrollHeight + 'px';
+                }
+            }
 
             // update faculty dropdown
             setFaculties('Okanagan');

--- a/resources/views/syllabus/syllabus.blade.php
+++ b/resources/views/syllabus/syllabus.blade.php
@@ -353,12 +353,44 @@
         </div>
 
         <div class="col-6">
-            <label for="endTime">Prerequisites</label><span class="requiredBySenateOK"></span>
-            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="100" spellcheck="true" id="prerequisites" name="prerequisites" class="form-control" type="text" value="{{ !empty($syllabus) ? $syllabus->prerequisites : ''}}">
+            <label for="prerequisites">Prerequisites</label><span class="requiredBySenateOK"></span>
+            <div id="formatPrereqs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i>
+                <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+            </div>
+            <textarea
+                data-formatnoteid="formatPrereqs"
+                oninput="validateMaxlength()"
+                onpaste="validateMaxlength()"
+                maxlength="7500"
+                id="prerequisites"
+                name="prerequisites"
+                class="form-control"
+                style="height:125px;"
+                type="text"
+                form="sylabusGenerator"
+                placeholder="E.g. COSC 111 or COSC 123&#10;MATH 221&#10;PSYO 111"
+                spellcheck="true">{{ !empty($syllabus) ? $syllabus->prerequisites : ''}}</textarea>
         </div>
         <div class="col-6">
-            <label for="endTime">Corequisites</label><span class="requiredBySenateOK"></span>
-            <input oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="100" spellcheck="true" id="corequisites" name="corequisites" class="form-control" type="text" value="{{ !empty($syllabus) ? $syllabus->corequisites : ''}}">
+            <label for="corequisites">Corequisites</label><span class="requiredBySenateOK"></span>
+            <div id="formatCoreqs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden;transition:height 0.3s ease-out;height:auto" data-collapsed="false">
+                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i>
+                <span class="fs-6">Place each entry on a new line for the best formatting results.</span>
+            </div>
+            <textarea
+                data-formatnoteid="formatCoreqs"
+                oninput="validateMaxlength()"
+                onpaste="validateMaxlength()"
+                maxlength="7500"
+                id="corequisites"
+                name="corequisites"
+                class="form-control"
+                style="height:125px;"
+                type="text"
+                form="sylabusGenerator"
+                placeholder="E.g. COSC 111&#10;COSC 123"
+                spellcheck="true">{{ !empty($syllabus) ? $syllabus->corequisites : ''}}</textarea>
         </div>
 
         <!-- Land Acknowledgement Statement -->

--- a/resources/views/syllabus/syllabus.blade.php
+++ b/resources/views/syllabus/syllabus.blade.php
@@ -354,10 +354,6 @@
 
         <div class="col-6">
             <label for="prerequisites">Prerequisites</label><span class="requiredBySenateOK"></span>
-            <div id="formatPrereqs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden; transition:height 0.3s ease-out; height:auto; font-size:0.5rem;">
-                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i>
-                <span style="font-size:0.80rem;">Place each entry on a new line for the best formatting results.</span>
-            </div>
             <textarea
                 data-formatnoteid="formatPrereqs"
                 oninput="autoResize(this)"
@@ -369,15 +365,11 @@
                 style="min-height:38px; max-height:200px; resize:none; overflow-y:hidden;"
                 rows="1"
                 form="sylabusGenerator"
-                placeholder="E.g. COSC 111 or COSC 123"
+                placeholder="E.g. COSC 111, COSC 123"
                 spellcheck="true">{{ !empty($syllabus) ? $syllabus->prerequisites : ''}}</textarea>
         </div>
         <div class="col-6">
             <label for="corequisites">Corequisites</label><span class="requiredBySenateOK"></span>
-            <div id="formatCoreqs" class="collapsibleNotes btn-primary rounded-3" style="overflow:hidden; transition:height 0.3s ease-out; height:auto; font-size:0.5rem;">
-                <i class="bi bi-exclamation-triangle-fill fs-5 pl-2 pr-2 pb-1"></i>
-                <span style="font-size:0.80rem;">Place each entry on a new line for the best formatting results.</span>
-            </div>
             <textarea
                 data-formatnoteid="formatCoreqs"
                 oninput="autoResize(this)"


### PR DESCRIPTION
## Description
This PR enhances both the input interface and display format of prerequisites and corequisites in the syllabus generator for the Okanagan campus. The changes improve the input experience with expandable text areas and modify the output format to use a numbered table layout.

## Changes
Input Interface Updates:
- Changed prerequisites and corequisites from single-line inputs to auto-expanding textareas
- Added dynamic resizing based on content (expands as user types or when viewing saved content)
- Improved formatting notes with more compact styling
- Maintained consistent behavior when viewing saved syllabi

Output Format Updates:
- Prerequisites and corequisites now display in a numbered table format
- Added support for parsing both comma-separated and newline-separated inputs
- Each prerequisite/corequisite gets its own row in the table
- Maintains consistency with Vancouver campus syllabus format

## Code Changes
Input Interface:
- Updated textarea styling to support auto-expansion
- Added JavaScript functions for dynamic resizing
- Modified input field initialization for existing content
- Adjusted formatting notes styling

Output Format:
- Updated prerequisite and corequisite handling in `SyllabusController.php`
- Changed from using `explode()` to `preg_split()` to handle multiple delimiter types
- Added input sanitization using `array_map('trim')` and `array_filter()`
- Modified template block handling to properly render tables

## Before and After
Input Interface Before:
```
Single line input field with fixed size
```

Input Interface After:
```
Auto-expanding textarea that grows with content
Compact formatting notes
Proper size retention when viewing saved content
```

Output Format Before:
```
Prerequisites: MATH100, MATH101, MATH102
```

Output Format After:
```
Prerequisites:
1. MATH100
2. MATH101
3. MATH102
```

## Testing Instructions
Input Interface Testing:
1. Create new syllabus and verify:
   - Textarea expands as you type
   - Formatting note is compact and readable
   - Can enter multiple lines of prerequisites
2. View existing syllabus and verify:
   - Textarea is properly sized to show all content
   - No need to scroll within small box to see content

Output Format Testing:
1. Create/Edit an Okanagan syllabus with:
   - Comma-separated prerequisites
   - Newline-separated prerequisites
   - Mixed format input
   - Empty prerequisites
   - Repeat tests for corequisites
2. Export to Word and verify table formatting

## Notes
- Test in both creation and viewing modes
- Verify proper handling of existing syllabi
- Ensure consistent behavior across different browsers
- Check Word document output formatting

## Dependencies
- No new dependencies added
- Uses existing PhpWord library for table generation

## Future Considerations
- Consider standardizing input format across both campuses
- Potentially extend auto-expanding textarea to other similar fields