### PR TITLE
Fixed Outcome Mapping Not Being Deleted

### DIFF
--- a/app/Http/Controllers/MappingScaleController.php
+++ b/app/Http/Controllers/MappingScaleController.php
@@ -163,6 +163,15 @@ class MappingScaleController extends Controller
             // if the mapping scale is null delete from the mapping scale program
             $msp = MappingScaleProgram::where('program_id', $request->input('program_id'))->where('map_scale_id', $map_scale_id);
 
+            //Also Deleting outcome mapping
+            //Get All PLOs for program
+            //Loop through each PLO, delete outcome where pl_outcome_id = Program and mapping scale ID = MS
+
+            $plos=ProgramLearningOutcome::where('program_id', $request->input('program_id'))->get();
+            foreach($plos as $plo){
+                OutcomeMap::where('map_scale_id', $map_scale_id)->where('pl_outcome_id', $plo->pl_outcome_id)->delete();
+            }
+
             if ($msp->delete()) {
                 // update courses 'updated_at' field
                 $program = Program::find($request->input('program_id'));
@@ -180,6 +189,15 @@ class MappingScaleController extends Controller
         } else {
             // if the mapping scale does not belong to a category the delete from mapping scales
             $ms = MappingScale::where('map_scale_id', $map_scale_id)->first();
+
+            //Also Deleting outcome mapping
+            //Get All PLOs for program
+            //Loop through each PLO, delete outcome where pl_outcome_id = Program and mapping scale ID = MS
+
+            $plos=ProgramLearningOutcome::where('program_id', $request->input('program_id'))->get();
+            foreach($plos as $plo){
+                OutcomeMap::where('map_scale_id', $map_scale_id)->where('pl_outcome_id', $plo->pl_outcome_id)->delete();
+            }
 
             if ($ms->delete()) {
                 // update courses 'updated_at' field


### PR DESCRIPTION
Added code to delete all Outcome Maps that are using the deleted mapping Scale + are mapped to a PLO that is owned by the program. Tested with multiple PLOs and multiple CLOs.