### PR TITLE
Add "Delete All" Functionality to Wizard Steps

### DIFF
--- a/app/Http/Controllers/PLOCategoryController.php
+++ b/app/Http/Controllers/PLOCategoryController.php
@@ -92,7 +92,6 @@ class PLOCategoryController extends Controller
             $program->last_modified_user = $user->name;
             $program->save();
             $request->session()->flash('success', 'Your PLO categories were updated successfully!');
-
         } catch (Throwable $exception) {
             $request->session()->flash('error', 'There was an error updating your PLO Categories');
         } finally {
@@ -182,5 +181,27 @@ class PLOCategoryController extends Controller
         }
 
         return redirect()->route('programWizard.step1', $request->input('program_id'));
+    }
+
+    public function destroyAll(Request $request, $programId): RedirectResponse
+    {
+        $program = Program::find($programId);
+
+        try {
+            // Delete all categories for this program
+            PLOCategory::where('program_id', $programId)->delete();
+
+            // Update program's last modified user
+            $user = User::find(Auth::id());
+            $program->last_modified_user = $user->name;
+            $program->touch();
+            $program->save();
+
+            $request->session()->flash('success', 'All PLO categories have been deleted');
+        } catch (Throwable $exception) {
+            $request->session()->flash('error', 'There was an error deleting the PLO categories');
+        }
+
+        return redirect()->route('programWizard.step1', $programId);
     }
 }

--- a/resources/views/courses/wizard/step1.blade.php
+++ b/resources/views/courses/wizard/step1.blade.php
@@ -17,7 +17,7 @@
                             @include('layouts.guide')
                         </div>
                     </h3>
-                    
+
                     <!-- Add CLO Modal: Bloom’s Taxonomy of Learning Modal -->
                     <div class="modal fade" data-backdrop="static" data-keyboard="false" id="addLearningOutcomeModal" tabindex="-1" role="dialog"
                         aria-labelledby="addLearningOutcomeModalLabel" aria-hidden="true">
@@ -37,7 +37,7 @@
                                                         <b>Course Learning Outcome (CLO)</b>
                                                         <div><small class="form-text text-muted" style="font-size:12px"><a href="https://tips.uark.edu/using-blooms-taxonomy/" target="_blank" rel="noopener noreferrer"><b><i class="bi bi-box-arrow-up-right"></i> Click here</b></a> for tips to write effective CLOs.</small></div>
                                                     </label>
-                
+
                                                     <textarea id="l_outcome" class="form-control" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="30000" name="l_outcome" required autofocus placeholder="E.g. Develop..." style="resize:none"></textarea>
                                                     <div class="invalid-tooltip">
                                                         You must input a course learning outcome or competency.
@@ -48,7 +48,7 @@
                                                         <b>Short Phrase</b>
                                                         <div><small class="form-text text-muted" style="font-size:12px"><b><i class="bi bi-exclamation-circle-fill text-warning" data-bs-toggle="tooltip" data-bs-placement="left" title="Having a short phrase helps with visualizing your course summary at the end of the mapping process"></i> 50 character limit.</b></small></div>
                                                     </label>
-                                                    <textarea id="title" class="form-control" name="title" autofocus placeholder="E.g Experimental Design..." maxlength="50" style="resize:none"></textarea> 
+                                                    <textarea id="title" class="form-control" name="title" autofocus placeholder="E.g Experimental Design..." maxlength="50" style="resize:none"></textarea>
                                                 </div>
                                                 <div class="col-2">
                                                     <button id="addCLOBtn" type="submit" class="btn btn-primary col mb-1">Add</button>
@@ -60,7 +60,7 @@
                                             <div class="col-8">
                                                 <hr>
                                             </div>
-                                        </div>                
+                                        </div>
 
                                         <div class="row m-1">
                                             <table id="addCLOTbl" class="table table-light table-borderless">
@@ -75,7 +75,7 @@
                                                     @foreach($l_outcomes as $index => $l_outcome)
                                                         <tr>
                                                             <td>
-                                                                <textarea name="current_l_outcome[{{$l_outcome->l_outcome_id}}]" value="{{$l_outcome->l_outcome}}" id="l_outcome{{$l_outcome->l_outcome_id}}" 
+                                                                <textarea name="current_l_outcome[{{$l_outcome->l_outcome_id}}]" value="{{$l_outcome->l_outcome}}" id="l_outcome{{$l_outcome->l_outcome_id}}"
                                                                 class="form-control @error('l_outcome') is-invalid @enderror" form="saveCLOChanges" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="30000" required>{{$l_outcome->l_outcome}}</textarea>
                                                             </td>
                                                             <td>
@@ -96,6 +96,7 @@
                                     @csrf
                                         <div class="modal-footer">
                                             <input type="hidden" name="course_id" value="{{$course->course_id}}" form="saveCLOChanges">
+                                            <button id="deleteAllCLOs" type="button" class="btn btn-danger col-3">Delete All</button>
                                             <button id="cancel" type="button" class="btn btn-secondary col-3" data-dismiss="modal">Cancel</button>
                                             <button type="submit" class="btn btn-success col-3">Save Changes</button>
                                         </div>
@@ -110,16 +111,16 @@
 
                 <div class="card-body">
                     <div class="alert alert-primary d-flex align-items-center" role="alert" style="text-align:justify">
-                        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>                        
+                        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>
                         <div>
                             <a href="https://ctl.ok.ubc.ca/teaching-development/classroom-practices/learning-outcomes/" target="_blank" rel="noopener noreferrer" class="alert-link">
                                 <i class="bi bi-box-arrow-up-right"></i> Course Learning Outcomes (CLOs)
-                            </a> 
-                            or 
+                            </a>
+                            or
                             <a href="https://sph.uth.edu/content/uploads/2012/01/Competencies-and-Learning-Objectives.pdf" target="_blank" rel="noopener noreferrer" class="alert-link">
                                 <i class="bi bi-box-arrow-up-right"></i> Competencies
-                            </a> 
-                            are the knowledge, skills and attributes that students are expected to attain by the end of a course. Add, edit and delete CLOs below. 
+                            </a>
+                            are the knowledge, skills and attributes that students are expected to attain by the end of a course. Add, edit and delete CLOs below.
                             You may use an excel spreadsheet to import multiple CLOs (use row 1 for headers and begin list of CLOs on row 2). Follow the template provided below to save them on your computer first, and then upload them to this page.
 
                         </div>
@@ -149,7 +150,7 @@
                     <div id="clo">
                         @if(count($l_outcomes)<1)
                             <div class="alert alert-warning wizard">
-                                <i class="bi bi-exclamation-circle-fill"></i>There are no course learning outcomes set for this course.                    
+                                <i class="bi bi-exclamation-circle-fill"></i>There are no course learning outcomes set for this course.
                             </div>
                         @else
                             <form action="{{route('courses.loReorder', $course->course_id)}}" method="POST">
@@ -163,7 +164,7 @@
                                     </tr>
                                         @foreach($l_outcomes as $index => $l_outcome)
                                         <tr>
-                                            <td class="text-center fw-bold" style="width:5%" >↕</td>                                                
+                                            <td class="text-center fw-bold" style="width:5%" >↕</td>
                                             <td>
                                                 <b>{{$l_outcome->clo_shortphrase}}</b><br>
                                                 {{$l_outcome->l_outcome}}
@@ -213,7 +214,7 @@
                                 </div>
                             </div>
 
-                        @endif      
+                        @endif
                     </div>
                 </div>
 
@@ -225,18 +226,24 @@
                             <button class="btn btn-sm btn-primary col-3 float-right">Student Assessment Methods <i class="bi bi-arrow-right mr-2"></i></button>
                         </a>
                     </div>
-                </div>            
+                </div>
             </div>
         </div>
     </div>
 </div>
 
 <script type="application/javascript">
-    
+
     $(document).ready(function () {
         // Enables functionality of tool tips
         $('[data-bs-toggle="tooltip"]').tooltip({html:true});
 
+        // To Delete All CLOs
+        $('#deleteAllCLOs').click(function() {
+            if (confirm('Are you sure you want to delete all CLOs? This cannot be undone.')) {
+                $('#addCLOTbl tbody').empty();
+            }
+        });
 
         $('#addCLOForm').submit(function (event) {
             // prevent default form submission handling
@@ -245,14 +252,14 @@
             // check if input fields contain data
             if ($('#l_outcome').val().length != 0) {
                 addCLO();
-                // reset form 
+                // reset form
                 $(this).trigger('reset');
                 $(this).removeClass('was-validated');
             } else {
                 // mark form as validated
                 $(this).addClass('was-validated');
             }
-            // readjust modal's position 
+            // readjust modal's position
             document.querySelector('#addLearningOutcomeModal').handleUpdate();
         });
 
@@ -261,7 +268,7 @@
                 @foreach($l_outcomes as $index => $l_outcome)
                     <tr>
                         <td>
-                            <textarea name="current_l_outcome[{{$l_outcome->l_outcome_id}}]" value="{{$l_outcome->l_outcome}}" id="l_outcome{{$l_outcome->l_outcome_id}}" 
+                            <textarea name="current_l_outcome[{{$l_outcome->l_outcome_id}}]" value="{{$l_outcome->l_outcome}}" id="l_outcome{{$l_outcome->l_outcome_id}}"
                             class="form-control @error('l_outcome') is-invalid @enderror" form="saveCLOChanges" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="30000" required>{{$l_outcome->l_outcome}}</textarea>
                         </td>
                         <td>
@@ -272,7 +279,7 @@
                             <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteCLO(this)"></i>
                         </td>
                     </tr>
-                @endforeach 
+                @endforeach
             `);
         });
     });
@@ -294,7 +301,7 @@
                 <td class="text-center">
                     <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteCLO(this)"></i>
                 </td>
-            </tr>        
+            </tr>
         `);
     }
 </script>

--- a/resources/views/courses/wizard/step1.blade.php
+++ b/resources/views/courses/wizard/step1.blade.php
@@ -98,7 +98,7 @@
                                             <input type="hidden" name="course_id" value="{{$course->course_id}}" form="saveCLOChanges">
                                             <button id="deleteAllCLOs" type="button" class="btn btn-danger col-3">Delete All</button>
                                             <button id="cancel" type="button" class="btn btn-secondary col-3" data-dismiss="modal">Cancel</button>
-                                            <button type="submit" class="btn btn-success col-3">Save Changes</button>
+                                            <button type="submit" class="btn btn-success col-3">Save</button>
                                         </div>
                                     </form>
 

--- a/resources/views/courses/wizard/step2.blade.php
+++ b/resources/views/courses/wizard/step2.blade.php
@@ -23,20 +23,20 @@
 
                 <div class="card-body">
                     <div class="alert alert-primary d-flex align-items-center" role="alert" style="text-align:justify">
-                        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>                        
+                        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>
                         <div>
                             Input all <a href="https://ctlt.ubc.ca/resources/webliography/assessmentevaluation/" target="_blank" rel="noopener noreferrer" class="alert-link">
                                 <i class="bi bi-box-arrow-up-right"></i> assessment methods
-                            </a> 
-                            of the course individually. You may also choose to use the 
+                            </a>
+                            of the course individually. You may also choose to use the
                             <a href="https://ubcoapps.elearning.ubc.ca/" target="_blank" rel="noopener noreferrer" class="alert-link"><i class="bi bi-box-arrow-up-right">
                                 </i> UBCO's Workload Calculator
-                            </a> 
-                            to estimate the student time commitment in this course based on the chosen assignments.              
+                            </a>
+                            to estimate the student time commitment in this course based on the chosen assignments.
                         </div>
                     </div>
 
-                    
+
                     <div class="row">
                         <div class="col">
                             <h6 class="card-subtitle mb-4 lh-lg">
@@ -61,23 +61,23 @@
                                     <th class="text-center"></th>
                                     <th>Student Assesment Methods</th>
                                     <th>Weight</th>
-                                    <th class="text-center w-25">Actions</th>                                    
+                                    <th class="text-center w-25">Actions</th>
                                 </tr>
                             </thead>
                             @if(count($a_methods)<1)
                                 <tr>
                                     <td colspan="4">
                                         <div class="alert alert-warning wizard">
-                                            <i class="bi bi-exclamation-circle-fill"></i>There are no student assessment methods set for this course.                    
+                                            <i class="bi bi-exclamation-circle-fill"></i>There are no student assessment methods set for this course.
                                         </div>
                                     </td>
                                 </tr>
                             @else
                                 @foreach($a_methods as $index=>$a_method)
                                     <tr>
-                                        <td class="text-center fw-bold" style="width:5%">↕</td>                                                
+                                        <td class="text-center fw-bold" style="width:5%">↕</td>
                                         <td>
-                                            {{$a_method->a_method}}                                                    
+                                            {{$a_method->a_method}}
                                         </td>
                                         <td >
                                             {{$a_method->weight}}%
@@ -126,7 +126,7 @@
                                                 <input id="assessmentMethod" class="form-control" list="assessmentMethodOptions" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="191" placeholder="Type to search or add your own..." required>
                                                 <div class="invalid-tooltip">
                                                     Please provide an assessment method.
-                                                </div>                                            
+                                                </div>
                                                 <datalist id="assessmentMethodOptions">
                                                     <option value="Annotated bibliography">
                                                     <option value="Assignment">
@@ -172,7 +172,7 @@
                                                         @foreach($custom_methods as $method)
                                                         <option value={{$method->custom_methods}}>
                                                         @endforeach
-                                                    @endif                                            
+                                                    @endif
                                                 </datalist>
                                             </div>
                                             <div class="col-4">
@@ -191,7 +191,7 @@
                                         <div class="col-8">
                                             <hr>
                                         </div>
-                                    </div> 
+                                    </div>
                                     <div class="row m-1">
                                         <table id="addAssessmentMethodsTbl" class="table table-light table-borderless">
                                             <thead>
@@ -209,28 +209,29 @@
                                                         <input list="assessmentMethodOptions" id="a_method{{$a_method->a_method_id}}" type="text" class="form-control @error('a_method') is-invalid @enderror" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="191"
                                                         name="current_a_methods[{{$a_method->a_method_id}}]" value = "{{$a_method->a_method}}" placeholder="Choose from the dropdown list or type your own" form="saveAssessmentMethodChanges" required>
                                                     </td>
-                                                    <td>                                                 
+                                                    <td>
                                                         <input class="p-1" id="a_method_weight{{$a_method->a_method_id}}" type="number" step="0.1" form="saveAssessmentMethodChanges" class="form-control @error('weight') is-invalid @enderror" value="{{$a_method->weight}}" name="current_weights[{{$a_method->a_method_id}}]" min="0" max="100" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="3" required>
                                                         <label for="a_method_weight{{$a_method->a_method_id}}" style="font-size: medium; margin-top:5px;margin-left:5px"><strong>%</strong></label>
                                                     </td>
                                                     <td class="text-center">
                                                         <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteAssessmentMethod(this)"></i>
                                                     </td>
-                                                    
+
                                                 </tr>
-                                                @endforeach                                        
+                                                @endforeach
                                             </tbody>
-                                        </table>                                    
+                                        </table>
                                     </div>
                                 </div>
                                 <form method="POST" id="saveAssessmentMethodChanges" action="{{ action([\App\Http\Controllers\AssessmentMethodController::class, 'store']) }}">
                                     @csrf
                                     <div class="modal-footer">
                                         <input type="hidden" name="course_id" value="{{$course->course_id}}" form="saveAssessmentMethodChanges">
+                                        <button id="deleteAllAssessmentMethods" type="button" class="btn btn-danger col-3">Delete All</button>
                                         <button id="cancel" type="button" class="btn btn-secondary col-3" data-bs-dismiss="modal">Cancel</button>
                                         <button type="submit" class="btn btn-success btn col-3" >Save Changes</button>
                                     </div>
-                                </form>    
+                                </form>
                             </div>
                         </div>
                     </div>
@@ -247,7 +248,7 @@
                             <button class="btn btn-sm btn-primary col-3 float-right">Teaching and Learning Activities <i class="bi bi-arrow-right ml-2"></i></button>
                         </a>
                     </div>
-                </div>            
+                </div>
             </div>
         </div>
     </div>
@@ -258,6 +259,13 @@
 
     $(document).ready(function () {
         sortDropdown();
+
+        // To Delete All Assessment Methods
+        $('#deleteAllAssessmentMethods').click(function() {
+            if (confirm('Are you sure you want to delete all assessment methods? This cannot be undone.')) {
+                $('#addAssessmentMethodsTbl tbody').empty();
+            }
+        });
         //   $("form").submit(function () {
         //     // prevent duplicate form submissions
         //     $(this).find(":submit").attr('disabled', 'disabled');
@@ -265,7 +273,7 @@
 
         //   });
 
-        
+
         $('#addAssessmentMethodForm').submit(function (event) {
             // prevent default form submission handling
             event.preventDefault();
@@ -273,14 +281,14 @@
             // check if input fields contain data
             if ($('#assessmentMethod').val().length != 0 && $('#weight').val() >= 0) {
                 addAssessmentMethod();
-                // reset form 
+                // reset form
                 $(this).trigger('reset');
                 $(this).removeClass('was-validated');
             } else {
                 // mark form as validated
                 $(this).addClass('was-validated');
             }
-            // readjust modal's position 
+            // readjust modal's position
             document.querySelector('#addAssessmentMethodModal').handleUpdate();
 
         });
@@ -292,7 +300,7 @@
                         <td>
                             <input list="assessmentMethodOptions" id="a_method{{$a_method->a_method_id}}" type="text" class="form-control @error('a_method') is-invalid @enderror" name="current_a_methods[{{$a_method->a_method_id}}]" value = "{{$a_method->a_method}}" placeholder="Choose from the dropdown list or type your own" form="saveAssessmentMethodChanges" required>
                         </td>
-                        <td>                                                 
+                        <td>
                             <input class="p-1" id="a_method_weight{{$a_method->a_method_id}}" type="number" step="0.1" form="saveAssessmentMethodChanges" class="form-control @error('weight') is-invalid @enderror" value="{{$a_method->weight}}" name="current_weights[{{$a_method->a_method_id}}]" min="0" max="100" required>
                             <label for="a_method_weight{{$a_method->a_method_id}}" style="font-size: medium; margin-top:5px;margin-left:5px"><strong>%</strong></label>
                         </td>
@@ -300,7 +308,7 @@
                             <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteAssessmentMethod(this)"></i>
                         </td>
                     </tr>
-                @endforeach 
+                @endforeach
             `);
         });
     });
@@ -317,14 +325,14 @@
                 <td>
                     <input list="assessmentMethodOptions" type="text" class="form-control @error('a_method') is-invalid @enderror" name="new_a_methods[]" value="${$('#assessmentMethod').val()}" placeholder="Choose from the dropdown list or type your own" form="saveAssessmentMethodChanges" required >
                 </td>
-                <td>                                                 
+                <td>
                     <input class="p-1" type="number" step="0.1" form="saveAssessmentMethodChanges" class="form-control @error('weight') is-invalid @enderror" value="${$('#weight').val()}" name="new_weights[]" min="0" max="100" required >
                     <label style="font-size: medium; margin-top:5px;margin-left:5px"><strong>%</strong></label>
                 </td>
                 <td class="text-center">
                     <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteAssessmentMethod(this)"></i>
                 </td>
-            </tr>        
+            </tr>
         `);
     }
 

--- a/resources/views/courses/wizard/step2.blade.php
+++ b/resources/views/courses/wizard/step2.blade.php
@@ -229,7 +229,7 @@
                                         <input type="hidden" name="course_id" value="{{$course->course_id}}" form="saveAssessmentMethodChanges">
                                         <button id="deleteAllAssessmentMethods" type="button" class="btn btn-danger col-3">Delete All</button>
                                         <button id="cancel" type="button" class="btn btn-secondary col-3" data-bs-dismiss="modal">Cancel</button>
-                                        <button type="submit" class="btn btn-success btn col-3" >Save Changes</button>
+                                        <button type="submit" class="btn btn-success btn col-3" >Save</button>
                                     </div>
                                 </form>
                             </div>

--- a/resources/views/courses/wizard/step3.blade.php
+++ b/resources/views/courses/wizard/step3.blade.php
@@ -37,7 +37,7 @@
                                             <input id="learningActivity" class="form-control" list="learningActivitiesOptions" oninput="validateMaxlength()" onpaste="validateMaxlength()" maxlength="191" placeholder="Type to search or add your own..." required>
                                             <div class="invalid-tooltip">
                                                 Please provide a learning activity.
-                                            </div>                                            
+                                            </div>
                                             <datalist id="learningActivitiesOptions">
                                                 <option value="Discussion">
                                                 <option value="Gallery walk">
@@ -67,7 +67,7 @@
                                                     @foreach($custom_activities as $activity)
                                                     <option value={{$activity->custom_activities}}>
                                                     @endforeach
-                                                @endif                                            
+                                                @endif
                                             </datalist>
                                         </div>
                                         <div class="col-2">
@@ -79,7 +79,7 @@
                                     <div class="col-8">
                                         <hr>
                                     </div>
-                                </div> 
+                                </div>
                                 <div class="row m-1">
                                     <table id="addLearningActivitiesTbl" class="table table-light table-borderless">
                                         <thead>
@@ -99,19 +99,20 @@
                                                     <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteLearningActivity(this)"></i>
                                                 </td>
                                             </tr>
-                                            @endforeach                                               
+                                            @endforeach
                                         </tbody>
-                                    </table>                                    
+                                    </table>
                                 </div>
                             </div>
                             <form method="POST" id="saveLearningActivityChanges" action="{{ action([\App\Http\Controllers\LearningActivityController::class, 'store']) }}">
                                 @csrf
                                 <div class="modal-footer">
                                     <input type="hidden" name="course_id" value="{{$course->course_id}}" form="saveLearningActivityChanges">
+                                    <button id="deleteAllLearningActivities" type="button" class="btn btn-danger col-3">Delete All</button>
                                     <button id="cancel" type="button" class="btn btn-secondary col-3" data-bs-dismiss="modal">Cancel</button>
                                     <button type="submit" class="btn btn-success btn col-3">Save Changes</button>
                                 </div>
-                            </form>    
+                            </form>
                         </div>
                     </div>
                 </div>
@@ -119,7 +120,7 @@
 
                 <div class="card-body">
                     <div class="alert alert-primary d-flex align-items-center" role="alert" style="text-align:justify">
-                        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>                        
+                        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>
                         <div class="col mb-6">
                             Input all teaching and learning activities or <a class="alert-link" target="_blank" rel="noopener noreferrer" href="https://teaching.cornell.edu/teaching-resources/teaching-cornell-guide/instructional-strategies"><i class="bi bi-box-arrow-up-right"></i> instructional strategies</a> of the course individually. Consider approaches to enhance inclusion in your classroom:
                             <ul>
@@ -128,10 +129,10 @@
                             (Offered by CAST) to design your course. You may also use <a class="alert-link" target="_blank" rel="noopener noreferrer" href="https://udlguidelines.cast.org/binaries/content/assets/common/publications/articles/cast-udl-planningq-a11y.pdf"><i class="bi bi-box-arrow-up-right"></i> these key questions to guide</a> you. </li>
                             <li>For concrete ways to decolonize your curriculum and pedagogy, explore <a class="alert-link" target="_blank" rel="noopener noreferrer" href="https://www.concordia.ca/ctl/decolonization/strategies.html"><i class="bi bi-box-arrow-up-right"></i> these strategies</a>.</li>
                             <li>
-                            Not sure how to teach/embed career-related outcomes? Request a workshop from The Career Development Team for your classroom <a class="alert-link" target="_blank" rel="noopener noreferrer" href="https://students.ok.ubc.ca/career-experience/faculty-workshops/"><i class="bi bi-box-arrow-up-right"></i> here</a>.              
+                            Not sure how to teach/embed career-related outcomes? Request a workshop from The Career Development Team for your classroom <a class="alert-link" target="_blank" rel="noopener noreferrer" href="https://students.ok.ubc.ca/career-experience/faculty-workshops/"><i class="bi bi-box-arrow-up-right"></i> here</a>.
                             </li>
                             <li>
-                            Embed <a class="alert-link" target="_blank" rel="noopener noreferrer" href="https://blogs.ubc.ca/teachingandwellbeing/files/2018/11/TLEF_Handout_October-2018.pdf"><i class="bi bi-box-arrow-up-right"></i>teaching practices</a>  that promote student wellbeing.</li> 
+                            Embed <a class="alert-link" target="_blank" rel="noopener noreferrer" href="https://blogs.ubc.ca/teachingandwellbeing/files/2018/11/TLEF_Handout_October-2018.pdf"><i class="bi bi-box-arrow-up-right"></i>teaching practices</a>  that promote student wellbeing.</li>
                             </ul>
                             </div>
                         </div>
@@ -158,14 +159,14 @@
                                     <tr>
                                         <td colspan="3">
                                             <div class="alert alert-warning wizard">
-                                                <i class="bi bi-exclamation-circle-fill"></i>There are no teaching and learning activities set for this course.                    
+                                                <i class="bi bi-exclamation-circle-fill"></i>There are no teaching and learning activities set for this course.
                                             </div>
                                         </td>
                                     </tr>
                                 @else
                                     @foreach($l_activities as $index => $l_activity)
                                         <tr>
-                                            <td class="text-center fw-bold" style="width:5%">↕</td>                                                
+                                            <td class="text-center fw-bold" style="width:5%">↕</td>
                                             <td>
                                                 {{$l_activity->l_activity}}
                                             </td>
@@ -196,7 +197,7 @@
                             <button class="btn btn-sm btn-primary col-3 float-right">Course Alignment <i class="bi bi-arrow-right ml-2"></i></button>
                         </a>
                     </div>
-                </div>            
+                </div>
             </div>
         </div>
    </div>
@@ -204,8 +205,14 @@
 
 <script>
     $(document).ready(function () {
-
         sortDropdown();
+
+        // To Delete All Learning Activities
+        $('#deleteAllLearningActivities').click(function() {
+            if (confirm('Are you sure you want to delete all learning activities? This cannot be undone.')) {
+                $('#addLearningActivitiesTbl tbody').empty();
+            }
+        });
     //   $("form").submit(function () {
     //     // prevent duplicate form submissions
     //     $(this).find(":submit").attr('disabled', 'disabled');
@@ -220,14 +227,14 @@
             // check if input fields contain data
             if ($('#learningActivity').val().length != 0) {
                 addLearningActivity();
-                // reset form 
+                // reset form
                 $(this).trigger('reset');
                 $(this).removeClass('was-validated');
             } else {
                 // mark form as validated
                 $(this).addClass('was-validated');
             }
-            // readjust modal's position 
+            // readjust modal's position
             document.querySelector('#addLearningActivitiesModal').handleUpdate();
 
         });
@@ -243,7 +250,7 @@
                             <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteLearningActivity(this)"></i>
                         </td>
                     </tr>
-                @endforeach                                               
+                @endforeach
             `);
         });
     });

--- a/resources/views/courses/wizard/step3.blade.php
+++ b/resources/views/courses/wizard/step3.blade.php
@@ -110,7 +110,7 @@
                                     <input type="hidden" name="course_id" value="{{$course->course_id}}" form="saveLearningActivityChanges">
                                     <button id="deleteAllLearningActivities" type="button" class="btn btn-danger col-3">Delete All</button>
                                     <button id="cancel" type="button" class="btn btn-secondary col-3" data-bs-dismiss="modal">Cancel</button>
-                                    <button type="submit" class="btn btn-success btn col-3">Save Changes</button>
+                                    <button type="submit" class="btn btn-success btn col-3">Save</button>
                                 </div>
                             </form>
                         </div>

--- a/resources/views/courses/wizard/step3.blade.php
+++ b/resources/views/courses/wizard/step3.blade.php
@@ -137,19 +137,20 @@
                             </div>
                         </div>
                     </div>
-                    <div class="row">
-                        <div class="col mb-1">
-                            <button type="button" class="btn btn-primary col-3 float-right bg-primary text-white fs-5"  data-bs-toggle="modal" data-bs-target="#addLearningActivitiesModal">
-                                <i class="bi bi-plus mr-2"></i>Learning Activities
-                            </button>
+                    <div class="container-fluid px-4" style="max-width: 1200px;">
+                        <div class="row">
+                            <div class="col mb-4">
+                                <button type="button" class="btn btn-primary col-3 float-right bg-primary text-white fs-5"  data-bs-toggle="modal" data-bs-target="#addLearningActivitiesModal">
+                                    <i class="bi bi-plus mr-2"></i>Learning Activities
+                                </button>
+                            </div>
                         </div>
-                    </div>
 
-                    <div id="admins">
+                        <div id="admins" class="mb-5">
                         <form action="{{route('courses.tlaReorder', $course->course_id)}}" method="POST">
                             @csrf
                             {{method_field('POST')}}
-                            <table class="table table-light reorder-tbl-rows" id="l_activity_table">
+                            <table class="table table-light reorder-tbl-rows mb-4" id="l_activity_table">
                                 <tr class="table-primary">
                                     <th class="text-center">#</th>
                                     <th>Teaching and Learning Activities</th>
@@ -180,7 +181,7 @@
                                     @endforeach
                                 @endif
                             </table>
-                            <div class="mt-4">
+                            <div class="mt-4 mb-5 pb-4">
                                 <button type="submit" class="btn btn-success float-right col-2">Save Order</button>
                             </div>
                         </form>

--- a/resources/views/courses/wizard/step3.blade.php
+++ b/resources/views/courses/wizard/step3.blade.php
@@ -139,7 +139,7 @@
                     </div>
                     <div class="container-fluid px-4" style="max-width: 1200px;">
                         <div class="row">
-                            <div class="col mb-4">
+                            <div class="col mb-1">
                                 <button type="button" class="btn btn-primary col-3 float-right bg-primary text-white fs-5"  data-bs-toggle="modal" data-bs-target="#addLearningActivitiesModal">
                                     <i class="bi bi-plus mr-2"></i>Learning Activities
                                 </button>

--- a/resources/views/programs/wizard/step1.blade.php
+++ b/resources/views/programs/wizard/step1.blade.php
@@ -19,7 +19,7 @@
                                 <i class="bi bi-info-circle-fill" data-bs-toggle="tooltip" data-bs-placement="right" title="Program learning outcome (PLO) categories can be used to group PLOs"></i>
                             </label>
                             <input id="PLOCategory" class="form-control" required>
-                            <div class="invalid-tooltip">Please provide a PLO category.</div>                                            
+                            <div class="invalid-tooltip">Please provide a PLO category.</div>
                         </div>
                         <div class="col-2">
                             <button id="addPLOCategoryBtn" type="submit" class="btn btn-primary col">Add</button>
@@ -30,8 +30,8 @@
                     <div class="col-8">
                         <hr>
                     </div>
-                </div> 
-                
+                </div>
+
                 <div class="row m-1">
                     <table id="addPLOCategoryTbl" class="table table-light table-borderless">
                         <thead>
@@ -50,9 +50,9 @@
                                     <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteRow(this)"></i>
                                 </td>
                             </tr>
-                        @endforeach                                               
+                        @endforeach
                         </tbody>
-                    </table>                                    
+                    </table>
                 </div>
             </div>
             <form method="POST" id="savePLOCategoryChanges" action="{{ action([\App\Http\Controllers\PLOCategoryController::class, 'store']) }}">
@@ -62,7 +62,7 @@
                     <button id="cancelPLOCategoryForm" type="button" class="btn btn-secondary col-3" data-bs-dismiss="modal">Cancel</button>
                     <button type="submit" class="btn btn-success btn col-3" >Save Changes</button>
                 </div>
-            </form>    
+            </form>
         </div>
     </div>
 </div>
@@ -86,7 +86,7 @@
                                 <b>Program Learning Outcome (PLO)</b>
                                 <div><small class="form-text text-muted" style="font-size:12px"><a href="https://tips.uark.edu/using-blooms-taxonomy/" target="_blank" rel="noopener noreferrer"><b><i class="bi bi-box-arrow-up-right"></i> Click here</b></a> for tips to write effective PLOs.</small></div>
                             </label>
-                
+
                             <textarea id="pl_outcome" rows="3" class="form-control" name="pl_outcome" required autofocus placeholder="E.g. Develop..." style="resize:none"></textarea>
                             <div class="invalid-tooltip">
                                 You must input a program learning outcome or competency.
@@ -117,7 +117,7 @@
                     <div class="col-8">
                         <hr>
                     </div>
-                </div>                
+                </div>
 
                 <div class="row m-1">
                     <table id="addPLOTbl" class="table table-light table-borderless">
@@ -138,7 +138,7 @@
                                 <td>
                                     <textarea type="text" name="current_pl_outcome_short_phrase[{{$pl_outcome->pl_outcome_id}}]" id="pl_outcome_short_phrase{{$pl_outcome->pl_outcome_id}}" class="form-control @error('clo_shortphrase') is-invalid @enderror"  form="savePLOChanges" maxlength="50" style="resize:none">{{$pl_outcome->plo_shortphrase}}</textarea>
                                 </td>
-                                <td>                  
+                                <td>
                                     <select class="form-select form-control" name="current_plo_category[{{$pl_outcome->pl_outcome_id}}]" style="height:4.7rem" id="plo_category{{$pl_outcome->pl_outcome_id}}" form="savePLOChanges">
                                         @if ($pl_outcome->category)
                                             <option value="{{$pl_outcome->category->plo_category_id}}" selected>{{$pl_outcome->category->plo_category}}</option>
@@ -148,7 +148,7 @@
                                                 @endif
                                             @endforeach
                                             <option value="">None</option>
-                                        @else 
+                                        @else
                                             <option value="" selected>None</option>
                                             @foreach ($ploCategories as $ploCat)
                                                 <option value="{{$ploCat->plo_category_id}}">{{$ploCat->plo_category}}</option>
@@ -202,10 +202,10 @@
 
                 <div class="card-body">
                     <div class="alert alert-primary d-flex align-items-center ml-3 mr-3" role="alert" style="text-align:justify">
-                        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>                        
+                        <i class="bi bi-info-circle-fill pr-2 fs-3"></i>
                         <div>
-                            Program learning outcomes (PLOs) are the knowledge, skills and attributes that students are expected to attain by the end of a program of study. Add, edit and delete PLOs below. 
-                            Categories can be used to group PLOs. 
+                            Program learning outcomes (PLOs) are the knowledge, skills and attributes that students are expected to attain by the end of a program of study. Add, edit and delete PLOs below.
+                            Categories can be used to group PLOs.
                             You may use an excel spreadsheet to import multiple PLOs/Categories (use row 1 for headers and begin list of PLOs on row 2). Follow the template below to save them on your computer first, and then upload them to this page.
 
                             <strong> Please note this website can only support a total of 20 PLOs per program (future updates will allow for more PLOs)</strong>.
@@ -225,15 +225,20 @@
                     <div class="card m-3">
                         <h5 class="card-header wizard text-start">
                             Categories (Can be used to group PLOs)
-                            <button type="button" class="btn bg-primary text-white btn-sm col-2 float-right" data-bs-toggle="modal" data-bs-target="#addPLOCategoryModal">
-                                <i class="bi bi-plus pr-2"></i>PLO Category
-                            </button>
+                            <div class="float-right">
+                                <button type="button" class="btn btn-danger btn-sm mr-2" style="width:180px" data-bs-toggle="modal" data-bs-target="#deleteAllCategoriesModal">
+                                    Delete All Categories
+                                </button>
+                                <button type="button" class="btn bg-primary text-white btn-sm" style="width:180px" data-bs-toggle="modal" data-bs-target="#addPLOCategoryModal">
+                                    <i class="bi bi-plus pr-2"></i>PLO Category
+                                </button>
+                            </div>
                         </h5>
 
                         <div class="card-body">
                             @if($ploCategories->count() < 1)
                                 <div class="alert alert-warning wizard">
-                                    <i class="bi bi-exclamation-circle-fill pr-2 fs-5"></i>There are no PLO categories set for this program yet.                    
+                                    <i class="bi bi-exclamation-circle-fill pr-2 fs-5"></i>There are no PLO categories set for this program yet.
                                 </div>
 
                             @else
@@ -245,11 +250,11 @@
 
                                     @foreach($ploCategories as $category)
                                     <tr>
-                                        <td>
+                                        <td data-category-id="{{$category->plo_category_id}}">
                                             {{$category->plo_category}}
                                         </td>
 
-                                        <td class="text-center align-middle">                                            
+                                        <td class="text-center align-middle">
                                             <button type="button" style="width:60px;" class="btn btn-secondary btn-sm m-1" data-bs-toggle="modal" data-bs-target="#editCategoryModal{{$category->plo_category_id}}">
                                                 Edit
                                             </button>
@@ -332,15 +337,20 @@
                     <div class="card m-3">
                         <h5 class="card-header wizard text-start">
                             Program Learning Outcomes (PLOs)
-                            <button type="button" class="btn bg-primary text-white btn-sm col-2 float-right" data-bs-toggle="modal" data-bs-target="#addPLOModal">
-                                <i class="bi bi-plus pr-2"></i>PLO
-                            </button>
+                            <div class="float-right">
+                                <button type="button" class="btn btn-danger btn-sm mr-2" style="width:180px" data-bs-toggle="modal" data-bs-target="#deleteAllPLOsModal">
+                                    Delete All PLOs
+                                </button>
+                                <button type="button" class="btn bg-primary text-white btn-sm" style="width:180px" data-bs-toggle="modal" data-bs-target="#addPLOModal">
+                                    <i class="bi bi-plus pr-2"></i>PLO
+                                </button>
+                            </div>
                         </h5>
                         <div class="card-body">
 
                             @if ( count($plos) < 1)
                                 <div class="alert alert-warning wizard">
-                                    <i class="bi bi-exclamation-circle-fill"></i>There are no program learning outcomes for this program.                  
+                                    <i class="bi bi-exclamation-circle-fill"></i>There are no program learning outcomes for this program.
                                 </div>
                             @else
                                 <table class="table table-light table-bordered table" style="width: 100%; margin: auto; table-layout:auto;">
@@ -362,14 +372,14 @@
                                                         <th class="text-left" colspan="3" style="background-color: #ebebeb;">{{$plo->plo_category}}</th>
                                                     </tr>
                                                     <tr class="alert alert-warning wizard">
-                                                        <th colspan="3" style="background-color: #fff3cd;"><i class="bi bi-exclamation-circle-fill pr-2 fs-5"></i>There are no program learning outcomes set for this PLO category. </th>              
+                                                        <th colspan="3" style="background-color: #fff3cd;"><i class="bi bi-exclamation-circle-fill pr-2 fs-5"></i>There are no program learning outcomes set for this PLO category. </th>
                                                     </tr>
                                                 @endif
                                             @endif
                                             <!-- Categorized PLOs -->
                                             @foreach($ploProgramCategories as $index => $ploCat)
                                                 @if ($plo->plo_category_id == $ploCat->plo_category_id)
-                                                    <tr>
+                                                    <tr data-plo-id="{{$ploCat->pl_outcome_id}}">
                                                         <td class="text-center" style="width: 10%;">{{$defaultShortFormsIndex[$ploCat->pl_outcome_id]}}</td>
                                                         <td>
                                                             <span style="font-weight: bold;">{{$ploCat->plo_shortphrase}}</span><br>
@@ -385,7 +395,7 @@
                                                         </td>
                                                     </tr>
                                                 @endif
-                                                
+
                                                 <!-- Delete PLO Confirmation Model -->
                                                 <div class="modal fade" id="deletePLO{{$ploCat->pl_outcome_id}}" tabindex="-1" role="dialog" aria-labelledby="deletePLO{{$ploCat->pl_outcome_id}}" aria-hidden="true">
                                                     <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered" role="document">
@@ -398,7 +408,7 @@
                                                             <div class="modal-body">
                                                                 @if ($ploCat->plo_shortphrase)
                                                                     Are you sure you want to delete program learning outcome: {{$ploCat->plo_shortphrase}}?
-                                                                @else 
+                                                                @else
                                                                     Are you sure you want to delete this program learning outcome?
                                                                 @endif
                                                             </div>
@@ -427,7 +437,7 @@
                                                                 <h5 class="modal-title" id="editPLOModalLabel">Edit Program Learning Outcome (PLO)</h5>
                                                                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                                             </div>
-                                                            
+
                                                             <form action="{{route('plo.update', $ploCat->pl_outcome_id)}}" method="POST">
                                                                 @csrf
                                                                 {{method_field('POST')}}
@@ -440,7 +450,7 @@
                                                                     <div class="form-floating mb-3">
                                                                         <input type="text" class="form-control" id="editPLOShortphraseInput{{$ploCat->pl_outcome_id}}" placeholder="E.g. Experimental Design" value="{{$ploCat->plo_shortphrase}}" name="title" maxlength="50">
                                                                         <label for="editPLOShortphraseInput{{$ploCat->pl_outcome_id}}">Short Phrase</label>
-                                                                        <small class="ml-2 form-text text-muted" style="font-size:12px"><i class="bi bi-exclamation-circle-fill text-warning mr-1" title=""></i> Having a short phrase helps with visualizing your program overview at the end of the mapping process (50 character limit)</small>                                     
+                                                                        <small class="ml-2 form-text text-muted" style="font-size:12px"><i class="bi bi-exclamation-circle-fill text-warning mr-1" title=""></i> Having a short phrase helps with visualizing your program overview at the end of the mapping process (50 character limit)</small>
                                                                     </div>
                                                                     <div class="form-floating mb-3">
                                                                         <select class="form-select" name="category" id="editPLOCatSelect{{$ploCat->pl_outcome_id}}" style="font-size:14px">
@@ -452,7 +462,7 @@
                                                                                     @endif
                                                                                 @endforeach
                                                                                 <option value="">None</option>
-                                                                            @else 
+                                                                            @else
                                                                                 <option value="" selected>None</option>
                                                                                 @foreach ($ploCategories as $ploCategory)
                                                                                     <option value="{{$ploCategory->plo_category_id}}">{{$ploCategory->plo_category}}</option>
@@ -489,7 +499,7 @@
                                             </tr>
                                         @endif
                                         @foreach($unCategorizedPLOS as $unCatIndex => $unCatplo)
-                                            <tr>
+                                            <tr data-plo-id="{{$unCatplo->pl_outcome_id}}">
                                                 <td class="text-center" style="width: 10%;">{{$defaultShortFormsIndex[$unCatplo->pl_outcome_id]}}</td>
                                                 <td>
                                                     <span style="font-weight: bold;">{{$unCatplo->plo_shortphrase}}</span><br>
@@ -515,7 +525,7 @@
                                                         <div class="modal-body">
                                                             @if ($unCatplo->plo_shortphrase)
                                                                 Are you sure you want to delete program learning outcome: {{$unCatplo->plo_shortphrase}}?
-                                                            @else 
+                                                            @else
                                                                 Are you sure you want to delete this program learning outcome?
                                                             @endif
                                                         </div>
@@ -540,7 +550,7 @@
                                                             <h5 class="modal-title" id="editPLOModalLabel">Edit Program Learning Outcome (PLO)</h5>
                                                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                                         </div>
-                                                        
+
                                                         <form action="{{route('plo.update', $unCatplo->pl_outcome_id)}}" method="POST">
                                                             @csrf
                                                             {{method_field('POST')}}
@@ -553,7 +563,7 @@
                                                                 <div class="form-floating mb-3">
                                                                     <input type="text" class="form-control" id="editPLOShortphraseInput{{$unCatplo->pl_outcome_id}}" placeholder="E.g. Experimental Design" value="{{$unCatplo->plo_shortphrase}}" name="title" maxlength="50">
                                                                     <label for="editPLOShortphraseInput{{$unCatplo->pl_outcome_id}}">Short Phrase</label>
-                                                                    <small class="ml-2 form-text text-muted" style="font-size:12px"><i class="bi bi-exclamation-circle-fill text-warning mr-1" title=""></i> Having a short phrase helps with visualizing your program overview at the end of the mapping process (50 character limit)</small>                                     
+                                                                    <small class="ml-2 form-text text-muted" style="font-size:12px"><i class="bi bi-exclamation-circle-fill text-warning mr-1" title=""></i> Having a short phrase helps with visualizing your program overview at the end of the mapping process (50 character limit)</small>
                                                                 </div>
                                                                 <div class="form-floating mb-3">
                                                                     <select class="form-select" name="category" id="editPLOCatSelect{{$unCatplo->pl_outcome_id}}" style="font-size:14px">
@@ -565,7 +575,7 @@
                                                                                 @endif
                                                                             @endforeach
                                                                             <option value="">None</option>
-                                                                        @else 
+                                                                        @else
                                                                             <option value="" selected>None</option>
                                                                             @foreach ($ploCategories as $ploCategory)
                                                                                 <option value="{{$ploCategory->plo_category_id}}">{{$ploCategory->plo_category}}</option>
@@ -635,14 +645,14 @@
             // check if input fields contain data
             if ($('#PLOCategory').val().length != 0) {
                 addPLOCategory();
-                // reset form 
+                // reset form
                 $(this).trigger('reset');
                 $(this).removeClass('was-validated');
             } else {
                 // mark form as validated
                 $(this).addClass('was-validated');
             }
-            // readjust modal's position 
+            // readjust modal's position
             document.querySelector('#addPLOCategoryModal').handleUpdate();
 
         });
@@ -655,7 +665,7 @@
             if ($('#pl_outcome').val().length != 0) {
                 addPLO();
                 removeHTMLSelectDuplicates();
-                // reset form 
+                // reset form
                 $(this).trigger('reset');
                 $(this).removeClass('was-validated');
             } else {
@@ -663,7 +673,7 @@
                 $(this).addClass('was-validated');
             }
             // readjust modal's position
-            var addP 
+            var addP
             document.querySelector('#addPLOModal').handleUpdate();
         });
 
@@ -678,7 +688,7 @@
                             <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteRow(this)"></i>
                         </td>
                     </tr>
-                @endforeach                                               
+                @endforeach
             `);
         });
 
@@ -692,7 +702,7 @@
                         <td>
                             <textarea type="text" name="current_pl_outcome_short_phrase[{{$pl_outcome->pl_outcome_id}}]" id="pl_outcome_short_phrase{{$pl_outcome->pl_outcome_id}}" class="form-control @error('clo_shortphrase') is-invalid @enderror"  form="savePLOChanges" maxlength="50" style="resize:none">{{$pl_outcome->plo_shortphrase}}</textarea>
                         </td>
-                        <td>                  
+                        <td>
                             <select class="form-select form-control" name="current_plo_category[{{$pl_outcome->pl_outcome_id}}]" style="height:4.7rem" id="plo_category{{$pl_outcome->pl_outcome_id}}" form="savePLOChanges" required>
                                 @if ($pl_outcome->category)
                                     <option value="{{$pl_outcome->category->plo_category_id}}" selected>{{$pl_outcome->category->plo_category}}</option>
@@ -702,7 +712,7 @@
                                         @endif
                                     @endforeach
                                     <option value="">None</option>
-                                @else 
+                                @else
                                     <option value="" selected>None</option>
                                     @foreach ($ploCategories as $ploCat)
                                         <option value="{{$ploCat->plo_category_id}}">{{$ploCat->plo_category}}</option>
@@ -734,7 +744,7 @@
                 <td class="text-center">
                     <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteRow(this)"></i>
                 </td>
-            </tr>        
+            </tr>
         `);
     }
 
@@ -748,7 +758,7 @@
                 <td>
                     <textarea type="text" name="new_pl_outcome_short_phrase[]" class="form-control"  form="savePLOChanges" maxlength="50" style="resize:none">${$('#ploShortphrase').val()}</textarea>
                 </td>
-                <td>                  
+                <td>
                     <select class="newPLOCatSelect unchecked form-select form-control" name="new_plo_category[]" style="height:4.7rem" form="savePLOChanges">
                         <option selected value="${$('#ploCategory option:selected').val()}">${$( "#ploCategory option:selected" ).text()}</option>
                         @foreach ($ploCategories as $ploCat)
@@ -760,7 +770,7 @@
                 <td class="text-center align-middle">
                     <i class="bi bi-x-circle-fill text-danger fs-4 btn" onclick="deleteRow(this)"></i>
                 </td>
-            </tr>        
+            </tr>
         `);
     }
 
@@ -783,4 +793,50 @@
         });
     }
 </script>
+
+<!-- Delete All Categories Confirmation Modal -->
+<div class="modal fade" id="deleteAllCategoriesModal" tabindex="-1" role="dialog" aria-labelledby="deleteAllCategoriesModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteAllCategoriesModalLabel">Delete All Categories</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form action="{{ route('program.category.destroyAll', $program->program_id) }}" method="POST">
+                @csrf
+                @method('DELETE')
+                <div class="modal-body">
+                    Are you sure you want to delete <b>all PLO categories</b>? This action <b>cannot be undone</b>.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Delete All</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Delete All PLOs Confirmation Modal -->
+<div class="modal fade" id="deleteAllPLOsModal" tabindex="-1" role="dialog" aria-labelledby="deleteAllPLOsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteAllPLOsModalLabel">Delete All PLOs</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form action="{{ route('program.plo.destroyAll', $program->program_id) }}" method="POST">
+                @csrf
+                @method('DELETE')
+                <div class="modal-body">
+                    Are you sure you want to delete <b>all program learning outcomes</b>? This action <b>cannot be undone</b>.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Delete All</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
 @endsection

--- a/resources/views/programs/wizard/step1.blade.php
+++ b/resources/views/programs/wizard/step1.blade.php
@@ -335,8 +335,12 @@
                         </div>
                     </div>
 
+                    <div class="mx-4 my-5">
+                        <hr class="border-1 border-secondary border-dashed opacity-10">
+                    </div>
+
                     <!-- Program Learning Outcomes -->
-                    <div class="card m-3">
+                    <div class="card m-3 mt-5">
                         <h5 class="card-header wizard text-start">
                             Program Learning Outcomes (PLOs)
                             <div class="float-right">

--- a/resources/views/programs/wizard/step1.blade.php
+++ b/resources/views/programs/wizard/step1.blade.php
@@ -226,9 +226,6 @@
                         <h5 class="card-header wizard text-start">
                             Categories (Can be used to group PLOs)
                             <div class="float-right">
-                                <button type="button" class="btn btn-danger btn-sm mr-2" style="width:180px" data-bs-toggle="modal" data-bs-target="#deleteAllCategoriesModal">
-                                    Delete All Categories
-                                </button>
                                 <button type="button" class="btn bg-primary text-white btn-sm" style="width:180px" data-bs-toggle="modal" data-bs-target="#addPLOCategoryModal">
                                     <i class="bi bi-plus pr-2"></i>PLO Category
                                 </button>
@@ -331,6 +328,11 @@
                                 </table>
                             @endif
                         </div>
+                        <div class="card-footer text-end">
+                            <button type="button" class="btn btn-danger btn-sm" style="width:180px" data-bs-toggle="modal" data-bs-target="#deleteAllCategoriesModal">
+                                Delete All Categories
+                            </button>
+                        </div>
                     </div>
 
                     <!-- Program Learning Outcomes -->
@@ -338,9 +340,6 @@
                         <h5 class="card-header wizard text-start">
                             Program Learning Outcomes (PLOs)
                             <div class="float-right">
-                                <button type="button" class="btn btn-danger btn-sm mr-2" style="width:180px" data-bs-toggle="modal" data-bs-target="#deleteAllPLOsModal">
-                                    Delete All PLOs
-                                </button>
                                 <button type="button" class="btn bg-primary text-white btn-sm" style="width:180px" data-bs-toggle="modal" data-bs-target="#addPLOModal">
                                     <i class="bi bi-plus pr-2"></i>PLO
                                 </button>
@@ -599,6 +598,11 @@
                                     </tbody>
                                 </table>
                             @endif
+                        </div>
+                        <div class="card-footer text-end">
+                            <button type="button" class="btn btn-danger btn-sm" style="width:180px" data-bs-toggle="modal" data-bs-target="#deleteAllPLOsModal">
+                                Delete All PLOs
+                            </button>
                         </div>
                     </div>
                     <!-- End Program Learning Outcomes -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -137,6 +137,7 @@ Route::post('/plo/store', [ProgramLearningOutcomeController::class, 'store'])->n
 Route::post('/import/plos', [ProgramLearningOutcomeController::class, 'import'])->name('program.outcomes.import');
 Route::delete('/plo/{program}/delete', [ProgramLearningOutcomeController::class, 'destroy'])->name('plo.destroy');
 Route::post('/plo/{program}/update', [ProgramLearningOutcomeController::class, 'update'])->name('plo.update');
+Route::delete('/program/{program}/plos/deleteAll', [ProgramLearningOutcomeController::class, 'destroyAll'])->name('program.plo.destroyAll');
 
 Route::resource('/la', LearningActivityController::class);
 Route::post('/la/store', [LearningActivityController::class, 'store'])->name('la.store');
@@ -163,6 +164,7 @@ Route::post('/mappingScale/{program}/update', [MappingScaleController::class, 'u
 Route::resource('/ploCategory', PLOCategoryController::class);
 Route::post('/ploCategory/store', [PLOCategoryController::class, 'store'])->name('program.category.store');
 Route::delete('/ploCategory/{program}/delete', [PLOCategoryController::class, 'destroy'])->name('program.category.destroy');
+Route::delete('/program/{program}/categories/deleteAll', [PLOCategoryController::class, 'destroyAll'])->name('program.category.destroyAll');
 Route::post('/ploCategory/{program}/update', [PLOCategoryController::class, 'update'])->name('program.category.update');
 
 Route::resource('/programUser', ProgramUserController::class);


### PR DESCRIPTION
## Description
Added "Delete All" buttons with confirmation modals across all wizard steps to improve bulk deletion workflows. This enhancement allows users to quickly clear all items in Course Learning Outcomes (CLOs), Program Learning Outcomes (PLOs), Assessment Methods, and Teaching & Learning Activities sections.

## Changes Made

### Added Delete All Functionality to:
- **Course Wizard**
  - Step 1: Course Learning Outcomes (CLOs)
  - Step 2: Assessment Methods
  - Step 3: Teaching & Learning Activities

- **Program Wizard**
  - Step 1: Program Learning Outcomes (PLOs) and PLO Categories

### Implementation Details
- Added consistent delete all buttons aligned with add buttons
- Implemented confirmation modals with:
  - Clear warning messages
  - Bold highlighting of important information
  - Proper cancel/confirm options
- Matched existing design patterns:
  - Button styling consistent with application
  - Modal dialogs following Bootstrap conventions
  - Fixed width buttons for visual alignment

### UI/UX Improvements
- Buttons sized consistently (180px width) for visual harmony
- Proper spacing between delete/add button pairs
- Clear visual hierarchy with danger styling for delete actions
- User-friendly confirmation flow to prevent accidental deletions

## Testing
- Verify delete all functionality works in all sections:
  - [ ] CLOs deletion with confirmation
  - [ ] Assessment Methods deletion with confirmation
  - [ ] Teaching & Learning Activities deletion with confirmation
  - [ ] PLOs deletion with confirmation
  - [ ] PLO Categories deletion with confirmation
- Verify modal behavior:
  - [ ] Closes on Cancel
  - [ ] Closes after successful deletion
  - [ ] Shows proper warning message
- Verify UI consistency:
  - [ ] Button alignment
  - [ ] Spacing between buttons
  - [ ] Modal styling matches application theme

## Screenshots
![image](https://github.com/user-attachments/assets/6f173344-8779-4ac9-8620-564a0f392912)
![image](https://github.com/user-attachments/assets/f46f8dc6-9696-4877-8805-2f2ed36a3e3c)
![image](https://github.com/user-attachments/assets/90926f70-9b38-4497-8d38-054587545dab)
![image](https://github.com/user-attachments/assets/28f5a34e-ee37-4a8d-a966-d57414a32482)
![image](https://github.com/user-attachments/assets/a7d0360e-0845-46ce-ab41-14193c5f0ba5)
