### PR TITLE
Standardize button sizes in the modals Step 4 Program Overview

### DIFF
--- a/resources/views/modals/confirmDownloadModal.blade.php
+++ b/resources/views/modals/confirmDownloadModal.blade.php
@@ -1,41 +1,41 @@
 
 <meta name="csrf-token" content="{{ csrf_token() }}">
                 <!-- Select program content modal -->
-                
+
                 <div class="modal" id="confirmDownloadModal" tabindex="-1" aria-labelledby="confirmDownloadModalLabel" aria-hidden="true" data-bs-backdrop="static">
                     <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered ">
                         <div class="modal-content">
                             <div class="modal-header">
                                 <h5 class="modal-title" id="confirmDownloadModalLabel">Confirm Action before Downloading</h5>
-                                
+
                                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                    
-                            </div> 
-            
+
+                            </div>
+
                             <div class="modal-body" style="height: auto;">
                                 <div class="alert alert-info d-flex align-items-center ml-3 mr-3" role="alert" style="text-align:justify">
-                                    <i class="bi bi-info-circle-fill pr-2 fs-1"></i>                        
+                                    <i class="bi bi-info-circle-fill pr-2 fs-1"></i>
                                         <div> Google Chrome and Mozilla Firefox are strongly recommended for this feature.</div>
-                                        
+
                                 </div>
-                                This feature is not optimized for use with other web browsers and may perform unexpectedly. 
-                                            
+                                This feature is not optimized for use with other web browsers and may perform unexpectedly.
+
                             </div>
                             <div class="modal-footer">
-                                <button style="width:60px" type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                                 <button id="confirmDownloadBtn"  data-bs-route="{{route('programs.spreadsheet', $program->program_id)}}" class="btn btn-primary">Confirm and Download</button>
                             </div>
 
                         </div>
                     </div>
-                </div> 
-                <!-- End of select program content modal --> 
+                </div>
+                <!-- End of select program content modal -->
                 <script type="application/javascript">
-                    
-                    
+
+
     $(document).ready(function () {
         var xhr;
-        
+
     });
 
 
@@ -54,7 +54,7 @@
         if (errorToast.hasClass("hide")) {
             errorToast.removeClass("hide");
             errorToast.addClass("show");
-        } 
+        }
     }
 
     // hide the error toast
@@ -63,7 +63,7 @@
         if (errorToast.hasClass("show")) {
             errorToast.removeClass("show");
             errorToast.addClass("hide");
-        } 
+        }
     }
 
 
@@ -82,6 +82,6 @@
             error: (jqXHR, textStatus, error) => {
                 console.log(error);
             },
-        }); 
+        });
     }
 </script>

--- a/resources/views/modals/dataConfirmDownloadModal.blade.php
+++ b/resources/views/modals/dataConfirmDownloadModal.blade.php
@@ -1,43 +1,43 @@
 
 <meta name="csrf-token" content="{{ csrf_token() }}">
                 <!-- Select program content modal -->
-                
+
                 <div class="modal" id="dataConfirmDownloadModal" tabindex="-1" aria-labelledby="dataConfirmDownloadModalLabel" aria-hidden="true" data-bs-backdrop="static">
                     <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered ">
                         <div class="modal-content">
                             <div class="modal-header">
                                 <h5 class="modal-title" id="dataConfirmDownloadModalLabel">Confirm Action before Downloading</h5>
-                                
+
                                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                    
-                            </div> 
-            
+
+                            </div>
+
                             <div class="modal-body" style="height: auto;">
                                 The new data import feature enables users to seamlessly export raw datasets, providing a flexible foundation for in-depth analysis and insights. Please checkout our User Guide for more information which can be downloaded here:
                                 <br>
                                 </n>
-                                <div style="text-align: center;"> 
-                                <div><button id="downloadUserGuideBtn"  data-bs-route="{{route('programs.downloadUserGuide', $program->program_id)}}" class="btn btn-primary btn-sm">Download User Guide</button></div>
+                                <div style="text-align: center;">
+                                <div><button id="downloadUserGuideBtn"  data-bs-route="{{route('programs.downloadUserGuide', $program->program_id)}}" class="btn btn-primary">Download User Guide</button></div>
                                 </div>
                             </div>
-                            
+
                             <div class="modal-footer">
-                            
-                                <button style="width:60px" type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
-                    
+
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+
                                 <button id="dataConfirmDownloadBtn"  data-bs-route="{{route('programs.dataSpreadsheet', $program->program_id)}}" class="btn btn-primary">Confirm and Download</button>
                             </div>
 
                         </div>
                     </div>
-                </div> 
-                <!-- End of select program content modal --> 
+                </div>
+                <!-- End of select program content modal -->
                 <script type="application/javascript">
-                    
-                    
+
+
     $(document).ready(function () {
         var xhr;
-        
+
     });
 
 
@@ -56,7 +56,7 @@
         if (errorToast.hasClass("hide")) {
             errorToast.removeClass("hide");
             errorToast.addClass("show");
-        } 
+        }
     }
 
     // hide the error toast
@@ -65,7 +65,7 @@
         if (errorToast.hasClass("show")) {
             errorToast.removeClass("show");
             errorToast.addClass("hide");
-        } 
+        }
     }
 
 
@@ -84,6 +84,6 @@
             error: (jqXHR, textStatus, error) => {
                 console.log(error);
             },
-        }); 
+        });
     }
 </script>

--- a/resources/views/modals/setContentPDF.blade.php
+++ b/resources/views/modals/setContentPDF.blade.php
@@ -1,23 +1,23 @@
 
 <meta name="csrf-token" content="{{ csrf_token() }}">
                 <!-- Select program content modal -->
-                
+
                 <div class="modal" id="setContentPDF" tabindex="-1" aria-labelledby="setContentPDFLabel" aria-hidden="true" data-bs-backdrop="static">
                     <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered ">
                         <div class="modal-content">
                             <div class="modal-header">
                                 <h5 class="modal-title" id="setContentPDFLabel">Select Content to Include in Program Summary</h5>
-                                
+
                                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                    
-                              
+
+
                             </div>
-            
+
                             <div class="modal-body" style="height: auto;">
                                 <form name="setContentForm" id="setContentForm">
                                 @csrf
                                 <div class="form-group">
-                                    <table class="table table-light table-bordered" style="margin: auto;"> 
+                                    <table class="table table-light table-bordered" style="margin: auto;">
                                         <thead>
                                             <tr class="table-primary">
                                                 <th>Content</th>
@@ -84,7 +84,7 @@
                                 </div>
                             </div>
                             <div class="modal-footer">
-                                <button style="width:60px" type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                                 <button id="downloadPartialPDFBtn"  data-route="{{route('programs.pdf', $program->program_id)}}" type="submit" class="btn btn-primary">Submit</button>
                                 <input value="1" name="formFilled" id="formFilled" form ="setContentForm"hidden>
                             </div>
@@ -94,11 +94,11 @@
                 </div>
                 <!-- End of select program content modal -->
                 <script type="application/javascript">
-                    
-                    
+
+
     $(document).ready(function () {
         var xhr;
-        
+
         $('#setContentForm').submit((e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -115,13 +115,13 @@
                 // show download modal
                 $('#setContentPDF').modal('toggle');
                 $('#downloadProgressModal').modal('show');
-                
-            },  
+
+            },
             success: (data, textStatus, jqXHR) => {
-                
+
                 $('#downloadProgressModal').modal('hide');
                 // check if controller handled an error
-                if (data == -1) 
+                if (data == -1)
                     showErrorToast()
                 else {
                     // close error toast if open
@@ -132,7 +132,7 @@
                     $("#save-file")[0].click();
                     // delete pdf summary after 15 sec/15,000 ms
 
-                    //Getting error 
+                    //Getting error
                     setTimeout(() => {deletePDF(route)}, 15000);
                 }
             },
@@ -140,17 +140,17 @@
                 // hide download modal
                 $('#downloadProgressModal').modal('hide');
                 if (textStatus != "abort") {
-                    // show error toast 
-                    showErrorToast();                
+                    // show error toast
+                    showErrorToast();
                 }
             },
-        });     
-           
         });
-        
+
+        });
+
     });
 
-    
+
 
     function abort(event) {
         if (xhr) {
@@ -167,7 +167,7 @@
         if (errorToast.hasClass("hide")) {
             errorToast.removeClass("hide");
             errorToast.addClass("show");
-        } 
+        }
     }
 
     // hide the error toast
@@ -176,7 +176,7 @@
         if (errorToast.hasClass("show")) {
             errorToast.removeClass("show");
             errorToast.addClass("hide");
-        } 
+        }
     }
 
 
@@ -195,6 +195,6 @@
             error: (jqXHR, textStatus, error) => {
                 console.log(error);
             },
-        }); 
+        });
     }
 </script>


### PR DESCRIPTION
This pull request includes changes to the modal button styles in multiple Blade template files. The primary change involves removing the `btn-sm` class and the inline width style from the 'Cancel' buttons to standardize their appearance.

## Changes to modal button styles:

* [`resources/views/modals/confirmDownloadModal.blade.php`](diffhunk://#diff-03706bd284ba39af955ee04611d37f457f441d044d442bdfa8f22d9ea0f0dadeL25-R25): Removed `btn-sm` class and inline width style from the 'Cancel' button.
* [`resources/views/modals/dataConfirmDownloadModal.blade.php`](diffhunk://#diff-f0dc3ccf466d4363d3b5b598d8db1f36e054511edcf5403ffea6d895ab37eaa1L20-R26): Removed `btn-sm` class and inline width style from the 'Cancel' button and the 'Download User Guide' button.
* [`resources/views/modals/setContentPDF.blade.php`](diffhunk://#diff-5d65a62cf8adea1df44ba3fa6e5b8e4be1c74fc0c7b793988531954ea3198167L87-R87): Removed `btn-sm` class and inline width style from the 'Cancel' button.


| **Before** | **After**|
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ee6aae52-df4f-4e46-84ff-d82ea2982aa2) | ![image](https://github.com/user-attachments/assets/4e9207dd-dfb8-4a23-9541-a9655dae9e1e) | 

| **Before** | **After** |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/bc185664-21f6-4e6c-b0a6-a518b5b5164a) | ![image](https://github.com/user-attachments/assets/b82c2867-d0a9-43ee-a699-4e8c52447011) | 

| **Before** | **After** |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/55116641-ff13-45d9-8870-d4e59c5af1e3) | ![image](https://github.com/user-attachments/assets/a9aa50b0-8370-4166-b6c0-ccc8237e3de2) | 