### PR TITLE
Standardize Modal Interactions with Bootstrap 5 Syntax

### DIFF
--- a/resources/views/courses/wizard/step1.blade.php
+++ b/resources/views/courses/wizard/step1.blade.php
@@ -18,14 +18,15 @@
                         </div>
                     </h3>
 
-                    <!-- Add CLO Modal: Bloom’s Taxonomy of Learning Modal -->
-                    <div class="modal fade" data-backdrop="static" data-keyboard="false" id="addLearningOutcomeModal" tabindex="-1" role="dialog"
+                    <!-- Add CLO Modal: Bloom's Taxonomy of Learning Modal -->
+                    <div class="modal fade" data-bs-backdrop="static" data-bs-keyboard="false" id="addLearningOutcomeModal" tabindex="-1" role="dialog"
                         aria-labelledby="addLearningOutcomeModalLabel" aria-hidden="true">
                         <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered" role="document">
                             <div class="modal-content">
                                 <div class="modal-header">
                                     <h5 class="modal-title" id="addLearningOutcomeModalLabel"><i class="bi bi-pencil-fill btn-icon mr-2"></i> Course Learning Outcomes or Competencies
                                     </h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                 </div>
 
                                 <div class="modal-body text-left">
@@ -97,7 +98,7 @@
                                         <div class="modal-footer">
                                             <input type="hidden" name="course_id" value="{{$course->course_id}}" form="saveCLOChanges">
                                             <button id="deleteAllCLOs" type="button" class="btn btn-danger col-3">Delete All</button>
-                                            <button id="cancel" type="button" class="btn btn-secondary col-3" data-dismiss="modal">Cancel</button>
+                                            <button id="cancel" type="button" class="btn btn-secondary col-3" data-bs-dismiss="modal">Cancel</button>
                                             <button type="submit" class="btn btn-success col-3">Save</button>
                                         </div>
                                     </form>
@@ -141,7 +142,7 @@
                             </div>
                         </form>
                         <div class="col-6 text-right">
-                            <button type="button" class="btn btn-primary btn-lg col-4 fs-5 bg-primary text-white"  data-toggle="modal" data-target="#addLearningOutcomeModal">
+                            <button type="button" class="btn btn-primary btn-lg col-4 fs-5 bg-primary text-white"  data-bs-toggle="modal" data-bs-target="#addLearningOutcomeModal">
                                 <b ><i class="bi bi-plus mr-2"></i>CLO</b>
                             </button>
                         </div>
@@ -170,7 +171,7 @@
                                                 {{$l_outcome->l_outcome}}
                                             </td>
                                             <td class="text-center align-middle">
-                                                <button type="button" style="width:60px;" class="btn btn-secondary btn-sm m-1" data-toggle="modal" data-target="#addLearningOutcomeModal">
+                                                <button type="button" style="width:60px;" class="btn btn-secondary btn-sm m-1" data-bs-toggle="modal" data-bs-target="#addLearningOutcomeModal">
                                                     Edit
                                                 </button>
                                                 <!-- <button style="width:60px;" type="button" class="btn btn-danger btn-sm btn btn-danger btn-sm m-1"
@@ -194,9 +195,7 @@
                                     <div class="modal-content">
                                         <div class="modal-header">
                                             <h5 class="modal-title" id="CLOdeleteConfirmation">Delete Confirmation</h5>
-                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                                <span aria-hidden="true">&times;</span>
-                                            </button>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                         </div>
                                         <div class="modal-body text-left">
                                         Are you sure you want to delete {{$l_outcome->l_outcome}}
@@ -206,7 +205,7 @@
                                             {{method_field('DELETE')}}
                                             <input type="hidden" name="course_id" value="{{$course->course_id}}">
                                             <div class="modal-footer">
-                                                <button style="width:60px" type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">Cancel</button>
+                                                <button style="width:60px" type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
                                                 <button style="width:60px;" type="submit" class="btn btn-danger btn-sm ">Delete</button>
                                             </div>
                                         </form>

--- a/resources/views/courses/wizard/step2.blade.php
+++ b/resources/views/courses/wizard/step2.blade.php
@@ -116,6 +116,7 @@
                             <div class="modal-content">
                                 <div class="modal-header">
                                     <h5 class="modal-title" id="addAssessmentMethodModalLabel"><i class="bi bi-pencil-fill btn-icon mr-2"></i> Student Assessment Methods</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                 </div>
 
                                 <div class="modal-body">

--- a/resources/views/courses/wizard/step3.blade.php
+++ b/resources/views/courses/wizard/step3.blade.php
@@ -27,6 +27,7 @@
                         <div class="modal-content">
                             <div class="modal-header">
                                 <h5 class="modal-title" id="addLearningActivitiesModalLabel"><i class="bi bi-pencil-fill btn-icon mr-2"></i> Teaching and Learning Activities</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                             </div>
 
                             <div class="modal-body">

--- a/resources/views/modals/confirmDownloadModal.blade.php
+++ b/resources/views/modals/confirmDownloadModal.blade.php
@@ -1,4 +1,3 @@
-
 <meta name="csrf-token" content="{{ csrf_token() }}">
                 <!-- Select program content modal -->
 
@@ -22,8 +21,8 @@
 
                             </div>
                             <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                                <button id="confirmDownloadBtn"  data-bs-route="{{route('programs.spreadsheet', $program->program_id)}}" class="btn btn-primary">Confirm and Download</button>
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" style="width: 120px;">Cancel</button>
+                                <button id="confirmDownloadBtn"  data-bs-route="{{route('programs.spreadsheet', $program->program_id)}}" class="btn btn-primary" style="width: 220px;">Confirm and Download</button>
                             </div>
 
                         </div>
@@ -44,7 +43,10 @@
             // abort XMLHttpRequest
             xhr.abort();
             // hide download modal
-            $('#downloadProgressModal').modal('hide');
+            var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+            if (downloadModal) {
+                downloadModal.hide();
+            }
         }
     }
 

--- a/resources/views/modals/dataConfirmDownloadModal.blade.php
+++ b/resources/views/modals/dataConfirmDownloadModal.blade.php
@@ -17,15 +17,15 @@
                                 <br>
                                 </n>
                                 <div style="text-align: center;">
-                                <div><button id="downloadUserGuideBtn"  data-bs-route="{{route('programs.downloadUserGuide', $program->program_id)}}" class="btn btn-primary">Download User Guide</button></div>
+                                <div><button id="downloadUserGuideBtn"  data-bs-route="{{route('programs.downloadUserGuide', $program->program_id)}}" class="btn btn-primary" style="width: 220px;">Download User Guide</button></div>
                                 </div>
                             </div>
 
                             <div class="modal-footer">
 
-                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" style="width: 120px;">Cancel</button>
 
-                                <button id="dataConfirmDownloadBtn"  data-bs-route="{{route('programs.dataSpreadsheet', $program->program_id)}}" class="btn btn-primary">Confirm and Download</button>
+                                <button id="dataConfirmDownloadBtn"  data-bs-route="{{route('programs.dataSpreadsheet', $program->program_id)}}" class="btn btn-primary" style="width: 220px;">Confirm and Download</button>
                             </div>
 
                         </div>
@@ -46,7 +46,10 @@
             // abort XMLHttpRequest
             xhr.abort();
             // hide download modal
-            $('#downloadProgressModal').modal('hide');
+            var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+            if (downloadModal) {
+                downloadModal.hide();
+            }
         }
     }
 

--- a/resources/views/modals/downloadProgressModal.blade.php
+++ b/resources/views/modals/downloadProgressModal.blade.php
@@ -10,7 +10,9 @@
                 @if (Request::is('programWizard/*'))
                     <h5 class="modal-title" id="downloadProgressModalLabel">Downloading program overview for {{$program->program}} ...</h5>
                 @endif
-            </div>  
+
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
             <div class="modal-body">
                 <p class="mb-2">This may take up to 5 minutes.</p>
                 <p class="mb-2">If this message does not go away automatically within 5 minutes or less, please close the window and check your Downloads folder.</p>
@@ -21,7 +23,7 @@
                 <a id="save-file" hidden download></a>
             </div>
             <div class="modal-footer">
-                <button id="cancelDownloadBtn" type="button" class="btn btn-secondary" aria-label="Close">Cancel</button>
+                <button id="cancelDownloadBtn" type="button" class="btn btn-secondary" data-bs-dismiss="modal" style="width: 120px;">Cancel</button>
             </div>
         </div>
     </div>
@@ -51,7 +53,7 @@
         $("#downloadUserGuideBtn").click((e) =>
             downloadUserGuide(e.currentTarget)
         )
-        
+
     });
 
     // Course level pdf
@@ -63,13 +65,17 @@
             dataType: "text",
             beforeSend: (jqXHR, settings) => {
                 // show download modal
-                $('#downloadProgressModal').modal('show');
-            },  
+                var downloadModal = new bootstrap.Modal(document.getElementById('downloadProgressModal'));
+                downloadModal.show();
+            },
             success: (data, textStatus, jqXHR) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 // check if controller handled an error
-                if (data == -1) 
+                if (data == -1)
                     showErrorToast()
                 else {
                     // close error toast if open
@@ -84,13 +90,16 @@
             },
             error: (jqXHR, textStatus, error) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 if (textStatus != "abort") {
-                    // show error toast 
-                    showErrorToast();                
+                    // show error toast
+                    showErrorToast();
                 }
             },
-        });     
+        });
     }
 
     // Course level excel
@@ -102,13 +111,17 @@
             dataType: "text",
             beforeSend: (jqXHR, settings) => {
                 // show download modal
-                $('#downloadProgressModal').modal('show');
-            },  
+                var downloadModal = new bootstrap.Modal(document.getElementById('downloadProgressModal'));
+                downloadModal.show();
+            },
             success: (data, textStatus, jqXHR) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 // check if controller handled an error
-                if (data == -1) 
+                if (data == -1)
                     showErrorToast()
                 else {
                     // close error toast if open
@@ -123,15 +136,18 @@
             },
             error: (jqXHR, textStatus, error) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 if (textStatus != "abort") {
-                    // show error toast 
-                    showErrorToast();                
+                    // show error toast
+                    showErrorToast();
                 }
             },
-        });     
+        });
     }
-        
+
 
     // Program Level excel with charts
     function downloadExcel(trigger) {
@@ -142,14 +158,21 @@
             dataType: "text",
             beforeSend: (jqXHR, settings) => {
                 // hide confirmation modal and show download modal
-                $('#confirmDownloadModal').modal('hide');
-                $('#downloadProgressModal').modal('show');
-            },  
+                var confirmModal = bootstrap.Modal.getInstance(document.getElementById('confirmDownloadModal'));
+                if (confirmModal) {
+                    confirmModal.hide();
+                }
+                var downloadModal = new bootstrap.Modal(document.getElementById('downloadProgressModal'));
+                downloadModal.show();
+            },
             success: (data, textStatus, jqXHR) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 // check if controller handled an error
-                if (data == -1) 
+                if (data == -1)
                     showErrorToast()
                 else {
                     // close error toast if open
@@ -164,16 +187,19 @@
             },
             error: (jqXHR, textStatus, error) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 if (textStatus != "abort") {
-                    // show error toast 
-                    showErrorToast();                
+                    // show error toast
+                    showErrorToast();
                 }
             },
-        });     
+        });
     }
 
-    // Program Level Data Excel 
+    // Program Level Data Excel
     function downloadDataExcel(trigger) {
         var route = "{{route('programs.dataSpreadsheet', $program->program_id)}}";
         xhr = $.ajax({
@@ -182,14 +208,21 @@
             dataType: "text",
             beforeSend: (jqXHR, settings) => {
                 // hide confirmation modal and show download modal
-                $('#dataConfirmDownloadModal').modal('hide');
-                $('#downloadProgressModal').modal('show');
-            },  
+                var dataConfirmModal = bootstrap.Modal.getInstance(document.getElementById('dataConfirmDownloadModal'));
+                if (dataConfirmModal) {
+                    dataConfirmModal.hide();
+                }
+                var downloadModal = new bootstrap.Modal(document.getElementById('downloadProgressModal'));
+                downloadModal.show();
+            },
             success: (data, textStatus, jqXHR) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 // check if controller handled an error
-                if (data == -1) 
+                if (data == -1)
                     showErrorToast()
                 else {
                     // close error toast if open
@@ -204,17 +237,20 @@
             },
             error: (jqXHR, textStatus, error) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 if (textStatus != "abort") {
-                    // show error toast 
-                    showErrorToast();                
+                    // show error toast
+                    showErrorToast();
                 }
             },
-        });     
+        });
     }
 
-        // Download User Guide
-        function downloadUserGuide(trigger) {
+    // Download User Guide
+    function downloadUserGuide(trigger) {
         var route = "{{route('programs.downloadUserGuide', $program->program_id)}}";
         xhr = $.ajax({
             type: "GET",
@@ -222,14 +258,21 @@
             dataType: "text",
             beforeSend: (jqXHR, settings) => {
                 // hide confirmation modal and show download modal
-                $('#dataConfirmDownloadModal').modal('hide');
-                $('#downloadProgressModal').modal('show');
-            },  
+                var dataConfirmModal = bootstrap.Modal.getInstance(document.getElementById('dataConfirmDownloadModal'));
+                if (dataConfirmModal) {
+                    dataConfirmModal.hide();
+                }
+                var downloadModal = new bootstrap.Modal(document.getElementById('downloadProgressModal'));
+                downloadModal.show();
+            },
             success: (data, textStatus, jqXHR) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 // check if controller handled an error
-                if (data == -1) 
+                if (data == -1)
                     showErrorToast()
                 else {
                     // close error toast if open
@@ -244,13 +287,16 @@
             },
             error: (jqXHR, textStatus, error) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 if (textStatus != "abort") {
-                    // show error toast 
-                    showErrorToast();                
+                    // show error toast
+                    showErrorToast();
                 }
             },
-        });     
+        });
     }
 
     function abort(event) {
@@ -258,7 +304,10 @@
             // abort XMLHttpRequest
             xhr.abort();
             // hide download modal
-            $('#downloadProgressModal').modal('hide');
+            var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+            if (downloadModal) {
+                downloadModal.hide();
+            }
         }
     }
 
@@ -268,7 +317,7 @@
         if (errorToast.hasClass("hide")) {
             errorToast.removeClass("hide");
             errorToast.addClass("show");
-        } 
+        }
     }
 
     // hide the error toast
@@ -277,7 +326,7 @@
         if (errorToast.hasClass("show")) {
             errorToast.removeClass("show");
             errorToast.addClass("hide");
-        } 
+        }
     }
 
 
@@ -296,6 +345,6 @@
             error: (jqXHR, textStatus, error) => {
                 console.log(error);
             },
-        }); 
+        });
     }
 </script>

--- a/resources/views/modals/setContentPDF.blade.php
+++ b/resources/views/modals/setContentPDF.blade.php
@@ -1,4 +1,3 @@
-
 <meta name="csrf-token" content="{{ csrf_token() }}">
                 <!-- Select program content modal -->
 
@@ -84,8 +83,8 @@
                                 </div>
                             </div>
                             <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                                <button id="downloadPartialPDFBtn"  data-route="{{route('programs.pdf', $program->program_id)}}" type="submit" class="btn btn-primary">Submit</button>
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" style="width: 120px;">Cancel</button>
+                                <button id="downloadPartialPDFBtn" data-route="{{route('programs.pdf', $program->program_id)}}" type="submit" class="btn btn-primary" style="width: 120px;">Submit</button>
                                 <input value="1" name="formFilled" id="formFilled" form ="setContentForm"hidden>
                             </div>
                         </form>
@@ -113,13 +112,19 @@
             },
             beforeSend: (jqXHR, settings) => {
                 // show download modal
-                $('#setContentPDF').modal('toggle');
-                $('#downloadProgressModal').modal('show');
-
+                var setContentModal = bootstrap.Modal.getInstance(document.getElementById('setContentPDF'));
+                if (setContentModal) {
+                    setContentModal.hide();
+                }
+                var downloadModal = new bootstrap.Modal(document.getElementById('downloadProgressModal'));
+                downloadModal.show();
             },
             success: (data, textStatus, jqXHR) => {
-
-                $('#downloadProgressModal').modal('hide');
+                // hide download modal
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 // check if controller handled an error
                 if (data == -1)
                     showErrorToast()
@@ -138,7 +143,10 @@
             },
             error: (jqXHR, textStatus, error) => {
                 // hide download modal
-                $('#downloadProgressModal').modal('hide');
+                var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+                if (downloadModal) {
+                    downloadModal.hide();
+                }
                 if (textStatus != "abort") {
                     // show error toast
                     showErrorToast();
@@ -157,7 +165,10 @@
             // abort XMLHttpRequest
             xhr.abort();
             // hide download modal
-            $('#downloadProgressModal').modal('hide');
+            var downloadModal = bootstrap.Modal.getInstance(document.getElementById('downloadProgressModal'));
+            if (downloadModal) {
+                downloadModal.hide();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
This PR completes the standardization of modal interactions across the application by updating all modals in the course and program wizard flow to use Bootstrap 5 modal methods and syntax consistently. The changes ensure proper functionality across all modals, including closing buttons, and backdrop behavior.

## Changes
- Added proper close buttons (`btn-close`) in modal headers across all steps
- Updated data attributes from Bootstrap 4 to Bootstrap 5 format:
  - `data-dismiss="modal"` → `data-bs-dismiss="modal"`
  - `data-toggle="modal"` → `data-bs-toggle="modal"`
  - `data-target="#modalId"` → `data-bs-target="#modalId"`
  - `data-backdrop="static"` → `data-bs-backdrop="static"`
  - `data-keyboard="false"` → `data-bs-keyboard="false"`
- Replaced the old `<button type="button" class="close">` with Bootstrap 5 style `<button type="button" class="btn-close">`
- Removed `<span aria-hidden="true">&times;</span>` from close buttons
- Updated JavaScript modal methods from jQuery to Bootstrap 5:
  - `$('#modalId').modal('show')` → `var modal = new bootstrap.Modal(document.getElementById('modalId')); modal.show();`
  - `$('#modalId').modal('hide')` → `var modal = bootstrap.Modal.getInstance(document.getElementById('modalId')); if(modal) modal.hide();`
  - `$('#modalId').modal('toggle')` → Replaced with conditional show/hide logic
- Standardized button widths and styling for consistent appearance
- Ensured consistent modal behavior across all wizard steps

## Modal Updates by File

### Programs Wizard
- **Step 4: Course Alignment (`resources/views/programs/wizard/step4.blade.php`)**
  - Updated SetContentPDF modal interactions with proper Bootstrap 5 methods
  - Enhanced Download Progress modal with correct Bootstrap 5 dismissal behavior
  - Updated all close buttons to the Bootstrap 5 format
  - Added proper data-bs-* attributes for all modal triggers

### Courses Wizard
- **Step 1: Course Learning Outcomes (`resources/views/courses/wizard/step1.blade.php`)**
  - Added close button to CLO modal header
  - Updated backdrop and keyboard attributes to Bootstrap 5 format
  - Updated modal trigger buttons with correct data-bs-* attributes
  - Updated Delete Confirmation modal with proper close/dismiss buttons

- **Step 2: Student Assessment Methods (`resources/views/courses/wizard/step2.blade.php`)**
  - Added close button to Assessment Method modal header
  - Modal already had most Bootstrap 5 attributes correctly implemented

- **Step 3: Teaching and Learning Activities (`resources/views/courses/wizard/step3.blade.php`)**
  - Added close button to Learning Activities modal header
  - Modal already had most Bootstrap 5 attributes correctly implemented

## Why is this important?
- **Consistency**: All modals now behave identically throughout the application
- **Maintainability**: Code follows the latest Bootstrap 5 standards
- **Functionality**: Properly implements ESC key handling and backdrop behavior
- **Accessibility**: Uses proper ARIA labels and semantics for close buttons
- **User Experience**: Standardized button sizes prevent text wrapping and improve readability

## Files changed
- `resources/views/programs/wizard/step4.blade.php`
- `resources/views/courses/wizard/step1.blade.php`
- `resources/views/courses/wizard/step2.blade.php`
- `resources/views/courses/wizard/step3.blade.php`

## Testing
- [x] Verified all modals open correctly with the updated trigger buttons
- [x] Confirmed modals close properly using the close (×) button 
- [x] Validated Cancel buttons properly dismiss modals
- [x] Confirmed static backdrop prevents closing when clicking outside
- [x] Tested in Chrome, and Edge

## Related Issues
Closes DS2025-8