### PR TITLE
Replace course required/not required buttons with toggle switches

### DIFF
--- a/resources/views/programs/wizard/step3.blade.php
+++ b/resources/views/programs/wizard/step3.blade.php
@@ -77,9 +77,12 @@
                                                             <input type="hidden" name="user_id" value="{{Auth::id()}}">
                                                             <input type="hidden" name="note" value="{{$programCourse->pivot->note}}">
                                                             <input type="hidden" name="required" value="{{$programCourse->pivot->course_required ? '0' : '1'}}">
-                                                            <button type="submit" class="btn btn-sm {{$programCourse->pivot->course_required ? 'btn-primary' : 'btn-outline-primary'}}">
-                                                                {{$programCourse->pivot->course_required ? 'Required' : 'Not Required'}}
-                                                            </button>
+                                                            <div class="form-check form-switch d-flex align-items-center course-switch">
+                                                                <input class="form-check-input switch-input" type="checkbox" id="flexSwitchCheck{{$programCourse->course_id}}" onchange="this.form.submit()" {{$programCourse->pivot->course_required ? 'checked' : ''}}>
+                                                                <label class="form-check-label ml-2" for="flexSwitchCheck{{$programCourse->course_id}}">
+                                                                    <span class="text-muted">{{$programCourse->pivot->course_required ? 'Required' : 'Not Required'}}</span>
+                                                                </label>
+                                                            </div>
                                                         </form>
                                                     </div>
                                                     <p class="form-text text-muted mt-2">
@@ -98,9 +101,12 @@
                                                             <input type="hidden" name="user_id" value="{{Auth::id()}}">
                                                             <input type="hidden" name="note" value="">
                                                             <input type="hidden" name="required" value="{{$programCourse->pivot->course_required ? '0' : '1'}}">
-                                                            <button type="submit" class="btn btn-sm {{$programCourse->pivot->course_required ? 'btn-primary' : 'btn-outline-primary'}}">
-                                                                {{$programCourse->pivot->course_required ? 'Required' : 'Not Required'}}
-                                                            </button>
+                                                            <div class="form-check form-switch d-flex align-items-center course-switch">
+                                                                <input class="form-check-input switch-input" type="checkbox" id="flexSwitchCheck{{$programCourse->course_id}}" onchange="this.form.submit()" {{$programCourse->pivot->course_required ? 'checked' : ''}}>
+                                                                <label class="form-check-label ml-2" for="flexSwitchCheck{{$programCourse->course_id}}">
+                                                                    <span class="text-muted">{{$programCourse->pivot->course_required ? 'Required' : 'Not Required'}}</span>
+                                                                </label>
+                                                            </div>
                                                         </form>
                                                     </div>
                                                 </td>
@@ -552,6 +558,34 @@
     text-align: left;
     max-width: 600px;
     width: auto;
+}
+
+/* Custom styles for the form switch */
+.form-check.form-switch {
+    padding-left: 0;
+    margin-bottom: 0;
+}
+
+.form-check.form-switch .form-check-input {
+    margin-left: 0;
+    margin-top: 0;
+}
+
+.form-check.form-switch .form-check-label {
+    padding-left: 30px;
+    font-size: 0.875rem;
+}
+
+/* .switch-input {
+    position: relative;
+    width: 40px;
+    height: 20px;
+} */
+
+.course-switch {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-left: 0;
 }
 </style>
 @endsection


### PR DESCRIPTION
### Description
This PR replaces the traditional buttons for toggling course required status with modern toggle switches to improve the user experience and interface consistency.

### Changes
- Replaced the "Required"/"Not Required" buttons with Bootstrap form-switch toggle switches
- Added styling to ensure proper alignment and spacing
- Made the Required/Not Required text appear in a muted color for better visual hierarchy
- Implemented automatic form submission on toggle change to reduce clicks
- Ensured consistent styling with existing toggle switches in the "Add Existing Course" modal

### Screenshots
**Before:**
![image](https://github.com/user-attachments/assets/06f2cf7a-8e4a-4a50-979d-be817d331c1d)

**After:**
![image](https://github.com/user-attachments/assets/b9c7beaf-560f-4564-a0ed-0c573077fbff)

### Testing
- Verified that toggling the switch correctly updates the course required status
- Confirmed that the form submits automatically when the switch is toggled

### Related Issues
Improves UI consistency across the application by using the same toggle switch pattern in multiple places. 