### PR TITLE
Added inclusion of the 'layouts.guide' in the syllabus view

### DIFF
--- a/resources/views/syllabus/syllabus.blade.php
+++ b/resources/views/syllabus/syllabus.blade.php
@@ -2,6 +2,8 @@
 
 @section('content')
 
+@include('layouts.guide')
+
 @include('modals.importCourseModal', ['myCourses' => $myCourses, 'syllabus' => $syllabus])
 
 @include('modals.courseSchedule')


### PR DESCRIPTION
Just adding `@include('layouts.guide')` to `syllabus.blade.php` so the help tooltips work correctly